### PR TITLE
Allow for restarting

### DIFF
--- a/docs/cu-mg-example.rst
+++ b/docs/cu-mg-example.rst
@@ -114,7 +114,7 @@ Mixing enthalpies are defined for the for the fcc, hcp, and Laves phases from DF
 
 The following command will generate a database named ``cu-mg_dft.tdb`` with parameters selected and fit by ESPEI::
 
-    espei --no-mcmc --fit-settings=Cu-Mg-input.json --input-data=input-data --output-tdb=cu-mg_dft.tdb
+    espei --no-mcmc --fit-settings=Cu-Mg-input.json --datasets=input-data --output-tdb=cu-mg_dft.tdb
 
 The calculation should be relatively quick, on the order of a minute of runtime.
 With the above command, only mininmal output (warnings) will be reported.
@@ -194,7 +194,7 @@ Now we will use our zero phase fraction equilibria data to optimize our first-pr
 The following command will take the database we created in the single-phase parameter selection and perform a MCMC optimization, creating a ``cu-mg_mcmc.tdb``::
 
 
-    espei --input-tdb=cu-mg_dft.tdb --fit-settings=Cu-Mg-input.json --input-data=input-data --output-tdb=cu-mg_mcmc.tdb
+    espei --input-tdb=cu-mg_dft.tdb --fit-settings=Cu-Mg-input.json --datasets=input-data --output-tdb=cu-mg_mcmc.tdb
 
 ESPEI defaults to run 1000 iterations and depends on calculating equilibrium in pycalphad several times for each iteration and the optimization is compute-bound.
 Fortunately, MCMC optimzations are embarrasingly parallel and ESPEI allows for parallelization using `dask <http://dask.pydata.org/>`_ or with MPI using `mpi4py <http://mpi4py.scipy.org/>`_ (single-node only at the time of writing - we are working on it).

--- a/espei/run_espei.py
+++ b/espei/run_espei.py
@@ -152,6 +152,13 @@ def main():
     tracefile = args.tracefile if args.tracefile else None
     probfile = args.probfile if args.probfile else None
     run_mcmc = not args.no_mcmc
+    # check that the MCMC output files do not already exist
+    # only matters if we are actually running MCMC
+    if run_mcmc:
+        if os.path.exists(tracefile):
+            raise OSError('Tracefile "{}" exists and would be overwritten by a new run. Use --tracefile to set a different name.'.format(tracefile))
+        if os.path.exists(probfile):
+            raise OSError('Probfile "{}" exists and would be overwritten by a new run. Use --probfile to set a different name.'.format(tracefile))
     if args.input_tdb:
         resume_tdb = Database(args.input_tdb)
     else:

--- a/espei/run_espei.py
+++ b/espei/run_espei.py
@@ -12,6 +12,7 @@ import logging
 import multiprocessing
 import sys
 
+import numpy as np
 from pycalphad import Database
 
 from espei import fit
@@ -35,14 +36,14 @@ parser.add_argument(
 parser.add_argument(
     "--tracefile",
     metavar="FILE",
-    default='chain.txt',
-    help="Output file for recording MCMC trace (txt). Defaults to chain.txt")
+    default='chain.npy',
+    help="Output file for recording MCMC trace array. Defaults to chain.npy")
 
 parser.add_argument(
     "--probfile",
     metavar="FILE",
-    default='lnprob.txt',
-    help="Output file for recording MCMC log probability (txt) corresponding to chain. Defaults to lnprob.txt")
+    default='lnprob.npy',
+    help="Output file for recording MCMC log probability array corresponding to chain. Defaults to lnprob.npy")
 
 parser.add_argument(
     "--fit-settings",
@@ -93,6 +94,11 @@ parser.add_argument(
     default=None,
     help="Check input datasets at the path. Does not run a fit.")
 
+parser.add_argument(
+    "--restart",
+    metavar="FILE",
+    default=None,
+    help="Restart a run with the specified chain trace. Requires input-tdb to be specified.")
 
 def main():
     args = parser.parse_args(sys.argv[1:])
@@ -147,13 +153,21 @@ def main():
     probfile = args.probfile if args.probfile else None
     run_mcmc = not args.no_mcmc
     if args.input_tdb:
-        resume = Database(args.input_tdb)
+        resume_tdb = Database(args.input_tdb)
     else:
-        resume = None
+        resume_tdb = None
+    if args.restart:
+        if not resume_tdb:
+            raise ValueError('The --input-tdb option must be specified in order to start a run from a previous chain.')
+        restart_chain = np.load(args.restart)
+    else:
+        restart_chain = None
+
     dbf, sampler, parameters = fit(args.fit_settings, datasets, scheduler=client,
                                    tracefile=tracefile, probfile=probfile,
-                                   resume=resume, run_mcmc=run_mcmc,
-                                   mcmc_steps=args.mcmc_steps, save_interval=args.save_interval)
+                                   resume=resume_tdb, run_mcmc=run_mcmc,
+                                   mcmc_steps=args.mcmc_steps, restart_chain=restart_chain,
+                                   save_interval=args.save_interval)
     dbf.to_file(args.output_tdb, if_exists='overwrite')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because MCMC fitting is relatively long-running and RAM intensive, it is ideal to be able to restart from a previous calculation. 

Currently, to restart, a user would manually update the parameters in the database to the parameters with the lowest probability from the previous run, then use that set of parameters to initialize a new set of walkers.

Since we save the state of the chains as the tracefile anyways, we can use the chains to restart a run in emcee and avoid tuning the walker initialization parameters on restart.

To make this (and analysis) easier, chains and log probabilities are now written out as binaries, rather than text files. This preserves the shape with the number of chains, so the chain file is now of shape (k, n, p), where k is number of walkers, n is the preallocated number of iterations, p is the number of parameters. The previous shape was (k*n, p). The same is true for the log probability file, which is now of shape (k, n) rather than (k*n). 

This change also introduces a command line argument `--restart` which takes the path to a chain file. If the name of the input chain conflicts with the default name, an error will be raised.