### PR TITLE
FIX: support TinyDB 3 by not changing configuration tuple to list in get_data

### DIFF
--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -11,7 +11,6 @@ from pycalphad import variables as v
 
 
 def get_data(comps, phase_name, configuration, symmetry, datasets, prop):
-    configuration = list(configuration)
     desired_data = datasets.search((tinydb.where('output').test(lambda x: x in prop)) &
                                    (tinydb.where('components').test(lambda x: set(x).issubset(comps))) &
                                    (tinydb.where('solver').test(symmetry_filter, configuration, symmetry)) &

--- a/espei/tests/test_core_utils.py
+++ b/espei/tests/test_core_utils.py
@@ -22,9 +22,7 @@ def test_get_data_for_a_minimal_example():
             "T": 298.15
         },
         "output": "HM_FORM",
-            "values":   [[[-15720, 34720, 7000, 15500]]],
-        "reference": "Zhou2007",
-        "comment": "DFT reported in S. H. Zhou et al., J. Phase Equilibria Diffus. 28, 158–166 (2007)."
+            "values":   [[[-15720, 34720, 7000, 15500]]]
     }
     datasets = PickleableTinyDB(storage=MemoryStorage)
     datasets.insert(SAMPLE_DATASET)

--- a/espei/tests/test_core_utils.py
+++ b/espei/tests/test_core_utils.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from espei.core_utils import get_data
+from espei.utils import PickleableTinyDB, MemoryStorage
+
+
+def test_get_data_for_a_minimal_example():
+    """Given a dataset and the congfiguration pertaining to that dataset, we should find the values."""
+    SAMPLE_DATASET = {
+        "components": ["CU", "MG", "VA"],
+        "phases": ["LAVES_C15"],
+        "solver": {
+            "mode": "manual",
+            "sublattice_site_ratios": [2, 1],
+            "sublattice_configurations": [["CU", "MG"],
+                                          ["MG", "CU"],
+                                          ["MG", "MG"],
+                                          ["CU", "CU"]]
+        },
+        "conditions": {
+            "P": 101325,
+            "T": 298.15
+        },
+        "output": "HM_FORM",
+            "values":   [[[-15720, 34720, 7000, 15500]]],
+        "reference": "Zhou2007",
+        "comment": "DFT reported in S. H. Zhou et al., J. Phase Equilibria Diffus. 28, 158–166 (2007)."
+    }
+    datasets = PickleableTinyDB(storage=MemoryStorage)
+    datasets.insert(SAMPLE_DATASET)
+    comps = ['CU', 'MG', 'VA']
+    phase_name = 'LAVES_C15'
+    configuration = ('MG', 'CU')
+    symmetry = None
+    desired_props = ['HM_FORM']
+
+    desired_data = get_data(comps, phase_name, configuration, symmetry, datasets, desired_props)
+    assert len(desired_data) == 1
+    desired_data = desired_data[0]
+    assert desired_data['components'] == comps
+    assert desired_data['phases'][0] == phase_name
+    assert desired_data['solver']['sublattice_site_ratios'] == [2, 1]
+    assert desired_data['solver']['sublattice_configurations'] == (('MG', 'CU'),)
+    assert desired_data['conditions']['P'] == 101325
+    assert desired_data['conditions']['T'] == 298.15
+    assert desired_data['output'] == 'HM_FORM'
+    assert desired_data['values'] == np.array([[[34720.0]]])

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -21,4 +21,4 @@ def test_pickelable_tinydb_can_be_pickled_and_unpickled():
     db = PickleableTinyDB(storage=MemoryStorage)
     db.insert(test_dict)
     db = pickle.loads(pickle.dumps(db))
-    assert db.search(where('test_key'))[0] == test_dict
+    assert db.search(where('test_key').exists())[0] == test_dict

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'six',
         'dask>=0.15',
         'distributed',
-        'tinydb<3',
+        'tinydb>=3',
         'scikit-learn',
         'emcee',
         'pycalphad>=0.5',


### PR DESCRIPTION
* Add a test for a minimal examples of finding data with get_data
* Fix an old test for the new explicit existence
* Update setup.py to require tinydb>=3