### PR TITLE
ENH: Add markers for each unique reference to dataplot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,10 @@ MOCK_MODULES = ['dask', 'distributed', 'emcee', 'emcee.utils',
                 'sympy', 'tinydb', 'pytest',
                 'tinydb.storages', 'numpy.linalg',
                 'cerberus', 'yaml',
-                'sympy'
+                'sympy',
+                'bibtexparser',
+                'bibtexparser.bparser',
+                'bibtexparser.customization',
                 ]
 
 for mod_name in MOCK_MODULES:

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -145,7 +145,6 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
                                        (tinydb.where('phases').test(lambda x: len(set(phases).intersection(x)) > 0)))
 
         # get all the possible references from the data and create the bibliography map
-        # TODO: Try to make a *second* legend that has the key for the symbols without reference to color
         # TODO: explore building tielines from multiphase equilibria. Should we do this?
         bib_reference_keys = sorted(list({entry['reference'] for entry in desired_data}))
         symbol_map = bib_marker_map(bib_reference_keys)
@@ -166,12 +165,18 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
         # now we will add the symbols for the references to the legend handles
         for ref_key in bib_reference_keys:
             mark = symbol_map[ref_key]['markers']
+            # The legend marker edge width appears smaller than in the plot.
+            # We will add this small hack to increase the width in the legend only.
+            legend_kwargs = scatter_kwargs.copy()
+            legend_kwargs['markeredgewidth'] *= 5
             legend_handles.append(mlines.Line2D([], [], linestyle='',
                                                 color='black', markeredgecolor='black',
                                                 label=symbol_map[ref_key]['formatted'],
                                                 fillstyle=mark['fillstyle'],
                                                 marker=mark['marker'],
-                                                **scatter_kwargs, ))
+                                                **legend_kwargs))
+
+        # finally, add the completed legend
         ax.legend(handles=legend_handles, loc='center left', bbox_to_anchor=(1, 0.5))
 
         # TODO: There are lot of ways this could break in multi-component situations

--- a/espei/tests/fixtures.py
+++ b/espei/tests/fixtures.py
@@ -1,5 +1,7 @@
 """Fixtures for use in tests"""
 
+import os, time
+
 import pytest
 from espei.utils import PickleableTinyDB, MemoryStorage
 
@@ -9,3 +11,14 @@ def datasets_db():
     db = PickleableTinyDB(storage=MemoryStorage)
     yield db
     db.close()
+
+@pytest.fixture
+def tmp_file():
+    """Create a temporary file with content and return the file name"""
+    fname = 'tmp_file-' + str(time.time()).split('.')[0]
+    def _tmp_file(content):
+        with open(fname, 'w') as fp:
+            fp.write(content)
+        return fname
+    yield _tmp_file
+    os.remove(fname)

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -1,10 +1,31 @@
 """
 Test espei.utils classes and functions.
 """
-import pickle
+import pickle, time, os
 
 from tinydb import where
-from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage
+from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage, flexible_open_string
+
+import pytest
+
+MULTILINE_HIPSTER_IPSUM = """Lorem ipsum dolor amet wayfarers kale chips chillwave
+adaptogen schlitz lo-fi jianbing ennui occupy pabst health goth chicharrones.
+Glossier enamel pin pitchfork PBR&B ennui. Actually small batch marfa edison
+bulb poutine, chicharrones neutra swag farm-to-table lyft meggings mixtape
+pork belly. DIY iceland schlitz YOLO, four loko pok pok single-origin coffee
+normcore. Shabby chic helvetica mustache taxidermy tattooed kombucha cliche
+gastropub gentrify ramps hexagon waistcoat authentic snackwave."""
+
+
+@pytest.fixture
+def tmp_file():
+    """Create a temporary file and return the file name"""
+    fname = 'tmp_file-' + str(time.time()).split('.')[0]
+    with open(fname, 'w') as fp:
+        fp.write(MULTILINE_HIPSTER_IPSUM)
+    yield fname
+    os.remove(fname)
+
 
 def test_immediate_client_returns_map_results_directly():
     """Calls ImmediateClient.map should return the results, instead of Futures."""
@@ -17,8 +38,30 @@ def test_immediate_client_returns_map_results_directly():
 
 
 def test_pickelable_tinydb_can_be_pickled_and_unpickled():
+    """PickleableTinyDB should be able to be pickled and unpickled."""
     test_dict = {'test_key': ['test', 'values']}
     db = PickleableTinyDB(storage=MemoryStorage)
     db.insert(test_dict)
     db = pickle.loads(pickle.dumps(db))
     assert db.search(where('test_key').exists())[0] == test_dict
+
+
+def test_flexible_open_string_raw_string():
+    """Raw multiline strings should be directly returned by flexible_open_string."""
+    returned_string = flexible_open_string(MULTILINE_HIPSTER_IPSUM)
+    assert returned_string == MULTILINE_HIPSTER_IPSUM
+
+
+def test_flexible_open_string_file_like(tmp_file):
+    """File-like objects support read methods should have their content returned by flexible_open_string."""
+    fname = tmp_file
+    with open(fname) as fp:
+        returned_string = flexible_open_string(fp)
+    assert returned_string == MULTILINE_HIPSTER_IPSUM
+
+
+def test_flexible_open_string_path_like(tmp_file):
+    """Path-like strings should be opened, read and returned"""
+    fname = tmp_file
+    returned_string = flexible_open_string(fname)
+    assert returned_string == MULTILINE_HIPSTER_IPSUM

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -90,11 +90,11 @@ def test_bib_marker_map():
     EXEMPLAR_DICT = {
         'bocklund2018': {
             'formatted': 'bocklund2018',
-            'markers': {'fillstyle': 'full', 'marker': 'o'}
+            'markers': {'fillstyle': 'none', 'marker': 'o'}
         },
         'otis2016': {
             'formatted': 'otis2016',
-            'markers': {'fillstyle': 'full', 'marker': 'v'}
+            'markers': {'fillstyle': 'none', 'marker': 'v'}
         }
     }
     assert EXEMPLAR_DICT == marker_dict

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -1,15 +1,14 @@
 """
 Test espei.utils classes and functions.
 """
-import pickle, time, os
+import pickle
 
 from tinydb import where
 from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage, \
     flexible_open_string, add_bibtex_to_bib_database
 
 import pytest
-from espei.tests.fixtures import datasets_db
-
+from espei.tests.fixtures import datasets_db, tmp_file
 
 MULTILINE_HIPSTER_IPSUM = """Lorem ipsum dolor amet wayfarers kale chips chillwave
 adaptogen schlitz lo-fi jianbing ennui occupy pabst health goth chicharrones.
@@ -18,16 +17,6 @@ bulb poutine, chicharrones neutra swag farm-to-table lyft meggings mixtape
 pork belly. DIY iceland schlitz YOLO, four loko pok pok single-origin coffee
 normcore. Shabby chic helvetica mustache taxidermy tattooed kombucha cliche
 gastropub gentrify ramps hexagon waistcoat authentic snackwave."""
-
-
-@pytest.fixture
-def tmp_file():
-    """Create a temporary file and return the file name"""
-    fname = 'tmp_file-' + str(time.time()).split('.')[0]
-    with open(fname, 'w') as fp:
-        fp.write(MULTILINE_HIPSTER_IPSUM)
-    yield fname
-    os.remove(fname)
 
 
 def test_immediate_client_returns_map_results_directly():
@@ -57,7 +46,7 @@ def test_flexible_open_string_raw_string():
 
 def test_flexible_open_string_file_like(tmp_file):
     """File-like objects support read methods should have their content returned by flexible_open_string."""
-    fname = tmp_file
+    fname = tmp_file(MULTILINE_HIPSTER_IPSUM)
     with open(fname) as fp:
         returned_string = flexible_open_string(fp)
     assert returned_string == MULTILINE_HIPSTER_IPSUM
@@ -65,7 +54,7 @@ def test_flexible_open_string_file_like(tmp_file):
 
 def test_flexible_open_string_path_like(tmp_file):
     """Path-like strings should be opened, read and returned"""
-    fname = tmp_file
+    fname = tmp_file(MULTILINE_HIPSTER_IPSUM)
     returned_string = flexible_open_string(fname)
     assert returned_string == MULTILINE_HIPSTER_IPSUM
 

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -4,9 +4,12 @@ Test espei.utils classes and functions.
 import pickle, time, os
 
 from tinydb import where
-from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage, flexible_open_string
+from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage, \
+    flexible_open_string, add_bibtex_to_bib_database
 
 import pytest
+from espei.tests.fixtures import datasets_db
+
 
 MULTILINE_HIPSTER_IPSUM = """Lorem ipsum dolor amet wayfarers kale chips chillwave
 adaptogen schlitz lo-fi jianbing ennui occupy pabst health goth chicharrones.
@@ -65,3 +68,30 @@ def test_flexible_open_string_path_like(tmp_file):
     fname = tmp_file
     returned_string = flexible_open_string(fname)
     assert returned_string == MULTILINE_HIPSTER_IPSUM
+
+
+def test_adding_bibtex_entries_to_bibliography_db(datasets_db):
+    """Adding a bibtex entries to a database works and the database can be searched."""
+    TEST_BIBTEX = """@article{Roe1952gamma,
+author = {Roe, W. P. and Fishel, W. P.},
+journal = {Trans. Am. Soc. Met.},
+keywords = {Fe-Cr,Fe-Ti,Fe-Ti-Cr},
+pages = {1030--1041},
+title = {{Gamma Loop Studies in the Fe-Ti, Fe-Cr, and Fe-Ti-Cr Systems}},
+volume = {44},
+year = {1952}
+}
+
+@phdthesis{shin2007thesis,
+author = {Shin, D},
+keywords = {Al-Cu,Al-Cu-Mg,Al-Cu-Si,Al-Mg,Al-Mg-Si,Al-Si,Cu-Mg,Mg-Si,SQS},
+number = {May},
+school = {The Pennsylvania State University},
+title = {{Thermodynamic properties of solid solutions from special quasirandom structures and CALPHAD modeling: Application to aluminum-copper-magnesium-silicon and hafnium-silicon-oxygen}},
+year = {2007}
+}"""
+    db = add_bibtex_to_bib_database(TEST_BIBTEX, datasets_db)
+    search_res = db.search(where('ID') == 'Roe1952gamma')
+    assert len(search_res) == 1
+    assert len(db.all()) == 2
+

--- a/espei/tests/test_utils.py
+++ b/espei/tests/test_utils.py
@@ -5,7 +5,7 @@ import pickle
 
 from tinydb import where
 from espei.utils import ImmediateClient, PickleableTinyDB, MemoryStorage, \
-    flexible_open_string, add_bibtex_to_bib_database
+    flexible_open_string, add_bibtex_to_bib_database, bib_marker_map
 
 import pytest
 from espei.tests.fixtures import datasets_db, tmp_file
@@ -60,7 +60,7 @@ def test_flexible_open_string_path_like(tmp_file):
 
 
 def test_adding_bibtex_entries_to_bibliography_db(datasets_db):
-    """Adding a bibtex entries to a database works and the database can be searched."""
+    """Adding a BibTeX entries to a database works and the database can be searched."""
     TEST_BIBTEX = """@article{Roe1952gamma,
 author = {Roe, W. P. and Fishel, W. P.},
 journal = {Trans. Am. Soc. Met.},
@@ -84,3 +84,17 @@ year = {2007}
     assert len(search_res) == 1
     assert len(db.all()) == 2
 
+def test_bib_marker_map():
+    """bib_marker_map should return a proper dict"""
+    marker_dict = bib_marker_map(['otis2016', 'bocklund2018'])
+    EXEMPLAR_DICT = {
+        'bocklund2018': {
+            'formatted': 'bocklund2018',
+            'markers': {'fillstyle': 'full', 'marker': 'o'}
+        },
+        'otis2016': {
+            'formatted': 'otis2016',
+            'markers': {'fillstyle': 'full', 'marker': 'v'}
+        }
+    }
+    assert EXEMPLAR_DICT == marker_dict

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -193,7 +193,7 @@ def bib_marker_map(bib_keys, markers=None):
     # TODO: support custom formatting from looking up keys in a bib_db
     if not markers:
         filled_markers = ['o', 'v', 's', 'd', 'P', 'X', '^', '<', '>']
-        fill_styles = ['full', 'top', 'right', 'bottom', 'left']
+        fill_styles = ['none', 'full', 'top', 'right', 'bottom', 'left']
         markers = itertools.product(fill_styles, filled_markers)
     b_m_map = dict()
     for ref, marker_tuple in zip(sorted(bib_keys), markers):

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -4,7 +4,7 @@ Utilities for ESPEI
 Classes and functions defined here should have some reuse potential.
 """
 
-import re
+import re, itertools
 import numpy as np
 from distributed import Client
 from tinydb import TinyDB
@@ -137,14 +137,14 @@ bibliography_database = PickleableTinyDB(storage=MemoryStorage)
 
 def add_bibtex_to_bib_database(bibtex, bib_db=None):
     """
-    Add entries from a bibtex file to the bibliography database
+    Add entries from a BibTeX file to the bibliography database
 
     Parameters
     ----------
     bibtex :
-        Either a multiline string, a path, or a file-like object of a bibtex file
+        Either a multiline string, a path, or a file-like object of a BibTeX file
     bib_db: PickleableTinyDB
-        Database to put the bibtex entries. Defaults to a module-level default database
+        Database to put the BibTeX entries. Defaults to a module-level default database
 
     Returns
     -------
@@ -158,3 +158,50 @@ def add_bibtex_to_bib_database(bibtex, bib_db=None):
     parsed_bibtex = bibtexparser.loads(bibtex_string, parser=parser)
     bib_db.insert_multiple(parsed_bibtex.entries)
     return bib_db
+
+
+def bib_marker_map(bib_keys, custom_markers=None):
+    """
+    Return a dict with reference keys and marker dicts
+
+    Parameters
+    ----------
+    bib_keys :
+    custom_markers : list
+        List of 2-tuples of ('marker', 'fillstyle') e.g. [('o', 'top'), ('s', 'left')].
+        Defaults to cycling through the filled markers, the different fill styles.
+
+    Returns
+    -------
+    dict
+        Dictionary with bib_keys as keys, dict values of formatted strings and marker dicts
+
+    Examples
+    --------
+    >>> bib_marker_map(['otis2016', 'bocklund2018'])
+    {
+    'bocklund2018': {
+                    'formatted': 'bocklund2018',
+                    'markers': {'fillstyle': 'full', 'marker': 'o'}
+                },
+    'otis2016': {
+                    'formatted': 'otis2016',
+                    'markers': {'fillstyle': 'full', 'marker': 'v'}
+                }
+    }
+    """
+    # TODO: support custom formatting from looking up keys in a bib_db
+    filled_markers = ['o', 'v', 's', 'd', 'P', 'X', '^', '<', '>']
+    fill_styles = ['full', 'top', 'right', 'bottom', 'left']
+    fill_marker_tuples = itertools.product(fill_styles, filled_markers)
+    b_m_map = dict()
+    for ref, marker_tuple in zip(sorted(bib_keys), fill_marker_tuples):
+        fill, marker = marker_tuple
+        b_m_map[ref] = {
+            'formatted': ref, # just use the key for formatting
+            'markers': {
+                'fillstyle': fill,
+                'marker': marker
+            }
+        }
+    return b_m_map

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -160,15 +160,15 @@ def add_bibtex_to_bib_database(bibtex, bib_db=None):
     return bib_db
 
 
-def bib_marker_map(bib_keys, custom_markers=None):
+def bib_marker_map(bib_keys, markers=None):
     """
     Return a dict with reference keys and marker dicts
 
     Parameters
     ----------
     bib_keys :
-    custom_markers : list
-        List of 2-tuples of ('marker', 'fillstyle') e.g. [('o', 'top'), ('s', 'left')].
+    markers : list
+        List of 2-tuples of ('fillstyle', 'marker') e.g. [('top', 'o'), ('full', 's')].
         Defaults to cycling through the filled markers, the different fill styles.
 
     Returns
@@ -191,17 +191,18 @@ def bib_marker_map(bib_keys, custom_markers=None):
     }
     """
     # TODO: support custom formatting from looking up keys in a bib_db
-    filled_markers = ['o', 'v', 's', 'd', 'P', 'X', '^', '<', '>']
-    fill_styles = ['full', 'top', 'right', 'bottom', 'left']
-    fill_marker_tuples = itertools.product(fill_styles, filled_markers)
+    if not markers:
+        filled_markers = ['o', 'v', 's', 'd', 'P', 'X', '^', '<', '>']
+        fill_styles = ['full', 'top', 'right', 'bottom', 'left']
+        markers = itertools.product(fill_styles, filled_markers)
     b_m_map = dict()
-    for ref, marker_tuple in zip(sorted(bib_keys), fill_marker_tuples):
-        fill, marker = marker_tuple
+    for ref, marker_tuple in zip(sorted(bib_keys), markers):
+        fill, mark = marker_tuple
         b_m_map[ref] = {
             'formatted': ref, # just use the key for formatting
             'markers': {
                 'fillstyle': fill,
-                'marker': marker
+                'marker': mark
             }
         }
     return b_m_map

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -141,7 +141,7 @@ def add_bibtex_to_bib_database(bibtex, bib_db=None):
 
     Parameters
     ----------
-    bibtex :
+    bibtex : str
         Either a multiline string, a path, or a file-like object of a BibTeX file
     bib_db: PickleableTinyDB
         Database to put the BibTeX entries. Defaults to a module-level default database

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'emcee',
         'pycalphad>=0.5',
         'pyyaml',
-        'cerberus'],
+        'cerberus',
+        'bibtexparser'],
     extras_require={
         'dev': [
             'sphinx',


### PR DESCRIPTION
Closes gh-23.

- Adds a TinyDB bibliographic database and utilities to add a BibTeX entries to it
- bibtexparser is now a dependency
- Better handling of aliases in dataplot plot_kwargs
- Utility to read multiline strings from raw strings, file paths, or streams

Note that there is no functionality here to format the references based on the database, but this functionality could easily be added with some handling of the references by using a formatting function that takes a BibTeX dict.



