### PR TITLE
ENH: Enable plotting of isothermal ZPF data in dataplot

### DIFF
--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -239,7 +239,7 @@ def _zpf_conditions_shape(zpf_values):
     return shape[-2]
 
 
-def ravel_conditions(values, *conditions, zpf=False):
+def ravel_conditions(values, *conditions, **kwargs):
     """
     Broadcast and flatten conditions to the shape dictated by the values.
 
@@ -254,8 +254,9 @@ def ravel_conditions(values, *conditions, zpf=False):
         of dimensions of the values array. In code, the following must be True:
         `all([s == len(cond) for s, cond in zip(values.shape, conditions)])`
 
-    zpf : bool
+    zpf : bool, optional
         Whether to consider values as a special case of ZPF data (not an even grid of conditions)
+        Default is False
 
     Returns
     -------
@@ -274,6 +275,8 @@ def ravel_conditions(values, *conditions, zpf=False):
     correct conditions because usually T and P are specified in ZPF (but, again,
     only one can actually be a condition given the current shape).
     """
+    # we have to parse the `zpf` kwarg manually because py27 does not allow named args after *args
+    zpf = kwargs.get('zpf')
     if zpf:
         values_shape = _zpf_conditions_shape(values)
         # we have to make our integers tuples

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -352,6 +352,9 @@ def ravel_zpf_values(desired_data, independent_comps, conditions=None):
                         c = list(independent_comps.difference(set(components)))[0]
                         x = None if any([xx is None for xx in compositions]) else 1 - sum(compositions)
                     comp_dict[c] = x
+                if conditions is None:
+                    # assume the other condition is temperature:
+                    comp_dict['T'] = temperature
                 this_equilibrium.append((phase_name, comp_dict, data['reference']))
 
             # add this set of equilibrium phases to the correct key in the equilibria dict

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -350,7 +350,7 @@ def ravel_zpf_values(desired_data, independent_comps, conditions=None):
                 for c, x in zip(components, compositions):
                     if c == mass_balance_dependent_comp:
                         c = list(independent_comps.difference(set(components)))[0]
-                        x = 1 - sum(compositions)
+                        x = None if any([xx is None for xx in compositions]) else 1 - sum(compositions)
                     comp_dict[c] = x
                 this_equilibrium.append((phase_name, comp_dict, data['reference']))
 

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -285,12 +285,10 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_
             updated_tieline_plot_kwargs.update(tieline_plot_kwargs)
         for eq in eq_dict.get(2,[]): # list of things in equilibrium
             # plot the scatter points for the right phases
-            x_points = []
-            y_points = []
+            x_points, y_points = [], []
             for phase_name, comp_dict, ref_key in eq:
                 sym_ref = symbol_map[ref_key]
-                x_val = comp_dict[x]
-                y_val = comp_dict[y]
+                x_val, y_val = comp_dict[x], comp_dict[y]
                 if x_val is not None and y_val is not None:
                     ax.plot(x_val, y_val,
                             label=sym_ref['formatted'],
@@ -313,11 +311,9 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_
             updated_tieline_plot_kwargs.update(tieline_plot_kwargs)
         for eq in eq_dict.get(3,[]): # list of things in equilibrium
             # plot the scatter points for the right phases
-            x_points = []
-            y_points = []
+            x_points, y_points = [], []
             for phase_name, comp_dict, ref_key in eq:
-                x_val = comp_dict[x]
-                y_val = comp_dict[y]
+                x_val, y_val = comp_dict[x], comp_dict[y]
                 x_points.append(x_val)
                 y_points.append(y_val)
             # Make sure the triangle completes

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -152,7 +152,7 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_
     >>> datasets = load_datasets(recursive_glob('.', '*.json'))
     >>> my_phases = ['BCC_A2', 'CUMG2', 'FCC_A1', 'LAVES_C15', 'LIQUID']
     >>> my_components = ['CU', 'MG' 'VA']
-    >>> conditions = {v.P: 101325, v.T: 1000, v.X('MG'): (0, 1, 0.01)}
+    >>> conditions = {v.P: 101325, v.T: (500, 1000, 10), v.X('MG'): (0, 1, 0.01)}
     >>> dataplot(my_components, my_phases, conditions, datasets)
 
     """
@@ -397,7 +397,7 @@ def eqdataplot(eq, datasets, ax=None, plot_kwargs=None):
     >>> datasets = load_datasets(recursive_glob('.', '*.json'))
     >>> dbf = Database('my_databases.tdb')
     >>> my_phases = list(dbf.phases.keys())
-    >>> eq = equilibrium(dbf, ['CU', 'MG', 'VA'], my_phases, {v.P: 101325, v.T: 1000, v.X('MG'): (0, 1, 0.01)})
+    >>> eq = equilibrium(dbf, ['CU', 'MG', 'VA'], my_phases, {v.P: 101325, v.T: (500, 1000, 10), v.X('MG'): (0, 1, 0.01)})
     >>> ax = eqplot(eq)
     >>> ax = eqdataplot(eq, datasets, ax=ax)
 

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -355,6 +355,7 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_
         # We will add this small hack to increase the width in the legend only.
         legend_kwargs = scatter_kwargs.copy()
         legend_kwargs['markeredgewidth'] = 1
+        legend_kwargs['markersize'] = 6
         legend_handles.append(mlines.Line2D([], [], linestyle='',
                                             color='black', markeredgecolor='black',
                                             label=symbol_map[ref_key]['formatted'],

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -15,7 +15,7 @@ from pycalphad.plot.eqplot import eqplot, _map_coord_to_variable, unpack_conditi
 
 from espei.utils import bib_marker_map
 from espei.core_utils import get_data, get_samples, list_to_tuple, \
-    endmembers_from_interaction, build_sitefractions
+    endmembers_from_interaction, build_sitefractions, ravel_zpf_values
 
 plot_mapping = {
     'T': 'Temperature (K)',
@@ -118,7 +118,7 @@ def plot_parameters(dbf, comps, phase_name, configuration, symmetry, datasets=No
             ax = _compare_data_to_parameters(dbf, comps, phase_name, data, mod, configuration, x_val, y_val, ax=ax)
 
 
-def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
+def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_plot_kwargs=None):
     """
     Plot datapoints corresponding to the components, phases, and conditions.
 
@@ -135,7 +135,9 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
     ax : matplotlib.Axes
         Default axes used if not specified.
     plot_kwargs : dict
-        Additional keyword arguments to pass to the matplotlib plot function
+        Additional keyword arguments to pass to the matplotlib plot function for points
+    tieline_plot_kwargs : dict
+        Additional keyword arguments to pass to the matplotlib plot function for tielines
 
     Returns
     -------
@@ -163,8 +165,6 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
     if len(indep_comps) == 1 and len(indep_pots) == 1:
         projection = None
     elif len(indep_comps) == 2 and len(indep_pots) == 0:
-        # TODO: support isotherm plotting
-        raise NotImplementedError('Triangular plotting is not yet implemented')
         projection = 'triangular'
     else:
         raise ValueError('The eqplot projection is not defined and cannot be autodetected. There are {} independent compositions and {} indepedent potentials.'.format(len(indep_comps), len(indep_pots)))
@@ -172,6 +172,9 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
     if projection is None:
         x = indep_comps[0].species
         y = indep_pots[0]
+    elif projection == 'triangular':
+        x = indep_comps[0].species
+        y = indep_comps[1].species
 
     # set up plot if not done already
     if ax is None:
@@ -183,17 +186,21 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
         plot_title = '-'.join([component.title() for component in sorted(comps) if component != 'VA'])
         ax.set_title(plot_title, fontsize=20)
         ax.set_xlabel('X({})'.format(x), labelpad=15, fontsize=20)
-        ax.set_ylabel(plot_mapping.get(str(y), y), fontsize=20)
         ax.set_xlim((0, 1))
-
-    # handle plotting kwargs
-    scatter_kwargs = {'markersize': 6, 'markeredgewidth': 0.2}
-    # raise warnings if any of the aliased versions of the default values are used
-    possible_aliases = [('markersize', 'ms'), ('markeredgewidth', 'mew')]
-    for actual_arg, aliased_arg in possible_aliases:
-        if aliased_arg in plot_kwargs:
-            warnings.warn("'{0}' passed as plotting keyword argument to dataplot, but the alias '{1}' is already set to '{2}'. Use the full version of the keyword argument '{1}' to override the default.".format(aliased_arg, actual_arg, scatter_kwargs.get(actual_arg)))
-    scatter_kwargs.update(plot_kwargs)
+        if projection is None:
+            ax.set_ylabel(plot_mapping.get(str(y), y), fontsize=20)
+        elif projection == 'triangular':
+            ax.set_ylabel('X({})'.format(y), labelpad=15, fontsize=20)
+            ax.set_ylim((0, 1))
+            ax.yaxis.label.set_rotation(60)
+            # Here we adjust the x coordinate of the ylabel.
+            # We make it reasonably comparable to the position of the xlabel from the xaxis
+            # As the figure size gets very large, the label approaches ~0.55 on the yaxis
+            # 0.55*cos(60 deg)=0.275, so that is the xcoord we are approaching.
+            ax.yaxis.label.set_va('baseline')
+            fig_x_size = ax.figure.get_size_inches()[0]
+            y_label_offset = 1 / fig_x_size
+            ax.yaxis.set_label_coords(x=(0.275 - y_label_offset), y=0.5)
 
     output = 'ZPF'
     # TODO: used to include VA. Should this be added by default. Can't determine presence of VA in eq.
@@ -220,25 +227,17 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
     phases.extend(new_phases)
     legend_handles, phase_color_map = phase_legend(phases)
 
-    # now we will add the symbols for the references to the legend handles
-    for ref_key in bib_reference_keys:
-        mark = symbol_map[ref_key]['markers']
-        # The legend marker edge width appears smaller than in the plot.
-        # We will add this small hack to increase the width in the legend only.
-        legend_kwargs = scatter_kwargs.copy()
-        legend_kwargs['markeredgewidth'] *= 5
-        legend_handles.append(mlines.Line2D([], [], linestyle='',
-                                            color='black', markeredgecolor='black',
-                                            label=symbol_map[ref_key]['formatted'],
-                                            fillstyle=mark['fillstyle'],
-                                            marker=mark['marker'],
-                                            **legend_kwargs))
-
-    # finally, add the completed legend
-    ax.legend(handles=legend_handles, loc='center left', bbox_to_anchor=(1, 0.5))
-
     if projection is None:
         # plot x vs. T
+        # handle plotting kwargs
+        scatter_kwargs = {'markersize': 6, 'markeredgewidth': 0.2}
+        # raise warnings if any of the aliased versions of the default values are used
+        possible_aliases = [('markersize', 'ms'), ('markeredgewidth', 'mew')]
+        for actual_arg, aliased_arg in possible_aliases:
+            if aliased_arg in plot_kwargs:
+                warnings.warn("'{0}' passed as plotting keyword argument to dataplot, but the alias '{1}' is already set to '{2}'. Use the full version of the keyword argument '{1}' to override the default.".format(aliased_arg, actual_arg, scatter_kwargs.get(actual_arg)))
+        scatter_kwargs.update(plot_kwargs)
+
         y = 'T'
 
         # TODO: There are lot of ways this could break in multi-component situations
@@ -289,6 +288,83 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None):
                 ax.plot(comps_ravelled[selected], temps_ravelled[selected],
                         fillstyle=fill_sym[0], marker=fill_sym[1], linestyle='',
                         **scatter_kwargs)
+    elif projection == 'triangular':
+        scatter_kwargs = {'markersize': 4, 'markeredgewidth': 0.4}
+        # raise warnings if any of the aliased versions of the default values are used
+        possible_aliases = [('markersize', 'ms'), ('markeredgewidth', 'mew')]
+        for actual_arg, aliased_arg in possible_aliases:
+            if aliased_arg in plot_kwargs:
+                warnings.warn("'{0}' passed as plotting keyword argument to dataplot, but the alias '{1}' is already set to '{2}'. Use the full version of the keyword argument '{1}' to override the default.".format(aliased_arg, actual_arg, scatter_kwargs.get(actual_arg)))
+        scatter_kwargs.update(plot_kwargs)
+
+        eq_dict = ravel_zpf_values(desired_data, [x, y], {'T': conds[v.T]})
+
+        # two phase
+        updated_tieline_plot_kwargs = {'linewidth':1, 'color':'k'}
+        if tieline_plot_kwargs is not None:
+            updated_tieline_plot_kwargs.update(tieline_plot_kwargs)
+        for eq in eq_dict.get(2,[]): # list of things in equilibrium
+            # plot the scatter points for the right phases
+            x_points = []
+            y_points = []
+            for phase_name, comp_dict, ref_key in eq:
+                sym_ref = symbol_map[ref_key]
+                x_val = comp_dict[x]
+                y_val = comp_dict[y]
+                if x_val is not None and y_val is not None:
+                    ax.plot(x_val, y_val,
+                            label=sym_ref['formatted'],
+                            fillstyle=sym_ref['markers']['fillstyle'],
+                            marker=sym_ref['markers']['marker'],
+                            linestyle='',
+                            color=phase_color_map[phase_name],
+                            **scatter_kwargs)
+                x_points.append(x_val)
+                y_points.append(y_val)
+
+            # plot the tielines
+            if all([xx is not None and yy is not None for xx, yy in zip(x_points, y_points)]):
+                ax.plot(x_points, y_points, **updated_tieline_plot_kwargs)
+
+
+        # three phase
+        updated_tieline_plot_kwargs = {'linewidth':1, 'color':'r'}
+        if tieline_plot_kwargs is not None:
+            updated_tieline_plot_kwargs.update(tieline_plot_kwargs)
+        for eq in eq_dict.get(3,[]): # list of things in equilibrium
+            # plot the scatter points for the right phases
+            x_points = []
+            y_points = []
+            for phase_name, comp_dict, ref_key in eq:
+                x_val = comp_dict[x]
+                y_val = comp_dict[y]
+                x_points.append(x_val)
+                y_points.append(y_val)
+            # Make sure the triangle completes
+            x_points.append(x_points[0])
+            y_points.append(y_points[0])
+            # plot
+            # check for None values
+            if all([xx is not None and yy is not None for xx, yy in zip(x_points, y_points)]):
+                ax.plot(x_points, y_points, **updated_tieline_plot_kwargs)
+
+    # now we will add the symbols for the references to the legend handles
+    for ref_key in bib_reference_keys:
+        mark = symbol_map[ref_key]['markers']
+        # The legend marker edge width appears smaller than in the plot.
+        # We will add this small hack to increase the width in the legend only.
+        legend_kwargs = scatter_kwargs.copy()
+        legend_kwargs['markeredgewidth'] = 1
+        legend_handles.append(mlines.Line2D([], [], linestyle='',
+                                            color='black', markeredgecolor='black',
+                                            label=symbol_map[ref_key]['formatted'],
+                                            fillstyle=mark['fillstyle'],
+                                            marker=mark['marker'],
+                                            **legend_kwargs))
+
+    # finally, add the completed legend
+    ax.legend(handles=legend_handles, loc='center left', bbox_to_anchor=(1, 0.5))
+
     return ax
 
 


### PR DESCRIPTION
- Add a ravel_conditions method to unpack the conditions in ESPEI datasets
- Add method to unpack the ZPF data into easily plottable data
- Propagate this new method back to the X vs. T plots
- Enable plotting of tielines in 2 and 3 component systems