### PR TITLE
FIX: Fix vacancy parameter generation

### DIFF
--- a/espei/paramselect.py
+++ b/espei/paramselect.py
@@ -217,8 +217,8 @@ def fit_formation_energy(dbf, comps, phase_name, configuration, symmetry, datase
     moles_per_formula_unit = sympy.S(0)
     subl_idx = 0
     for num_sites, const in zip(dbf.phases[phase_name].sublattices, dbf.phases[phase_name].constituents):
-        if 'VA' in const:
-            moles_per_formula_unit += num_sites * (1 - v.SiteFraction(phase_name, subl_idx, 'VA'))
+        if Species('VA') in const:
+            moles_per_formula_unit += num_sites * (1 - v.SiteFraction(phase_name, subl_idx, Species('VA')))
         else:
             moles_per_formula_unit += num_sites
         subl_idx += 1

--- a/espei/tests/test_parameter_generation.py
+++ b/espei/tests/test_parameter_generation.py
@@ -44,6 +44,7 @@ def test_mixing_energies_are_fit(datasets_db):
     assert dbf.elements == {'AL', 'B'}
     assert set(dbf.phases.keys()) == {'LIQUID', 'FCC_A1'}
     assert len(dbf._parameters.search(where('parameter_type') == 'L')) == 1
+    assert dbf.symbols['VV0000'] == -40000
 
     # check that read/write is ok
     read_dbf = dbf.from_string(dbf.to_string(fmt='tdb'), fmt='tdb')
@@ -54,6 +55,45 @@ def test_mixing_energies_are_fit(datasets_db):
     # the error should be exactly 0 because we are only fitting to one point
     from espei.error_functions import calculate_thermochemical_error
     assert calculate_thermochemical_error(read_dbf, sorted(dbf.elements), sorted(dbf.phases.keys()), datasets_db) == 0
+
+
+def test_multi_sublattice_mixing_energies_are_fit(datasets_db):
+    """Tests the correct excess parameter is fit for phases with multiple sublattices with vacancies."""
+    phase_models = {
+        "components": ["AL", "B", "VA"],
+        "phases": {
+            "FCC_A1" : {
+                "sublattice_model": [["AL", "B"], ["AL", "VA"]],
+                "sublattice_site_ratios": [1, 3]
+            }
+        }
+    }
+
+    dataset_excess_mixing = {
+        "components": ["AL", "B", "VA"],
+        "phases": ["FCC_A1"],
+        "solver": {
+            "sublattice_site_ratios": [1, 3],
+            "sublattice_occupancies": [[[0.5, 0.5], 1], [[0.5, 0.5], 1]],
+            "sublattice_configurations": [[["AL", "B"], "VA"], [["AL", "B"], "AL"]],
+            "mode": "manual"
+        },
+        "conditions": {
+            "P": 101325,
+            "T": 298.15
+        },
+        "output": "HM_MIX",
+        "values": [[[-10000, -10000]]]
+    }
+    datasets_db.insert(dataset_excess_mixing)
+
+    dbf = generate_parameters(phase_models, datasets_db, 'SGTE91', 'linear')
+
+    assert set(dbf.phases.keys()) == {'FCC_A1'}
+    assert len(dbf._parameters.search(where('parameter_type') == 'L')) == 2
+    assert dbf.symbols['VV0000'] == -160000.0
+    assert dbf.symbols['VV0001'] == -40000.0
+
 
 def test_sgte_reference_state_naming_is_correct_for_character_element(datasets_db):
     """Elements with single character names should get the correct GHSER reference state name (V => GHSERVV)"""


### PR DESCRIPTION
Fix paramselect bug where vacancy species were not getting subtracted from the moles per formula unit. Includes a test to prevent future regressions.