### PR TITLE
FIX: Fix MCMC thermochemical error for P/T/points arrays

### DIFF
--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -160,4 +160,7 @@ def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phas
         target_chempots = target_chempots_from_activity(acr_component, np.array(ds['values']).flatten(), conditions[v.T], ref_result)
         # calculate the error
         error += chempot_error(current_chempots, target_chempots)
+    # TODO: write a test for this
+    if np.any(np.isnan(np.array([error], dtype=np.float64))):  # must coerce sympy.core.numbers.Float to float64
+        return -np.inf
     return error

--- a/espei/error_functions/thermochemical_error.py
+++ b/espei/error_functions/thermochemical_error.py
@@ -143,8 +143,6 @@ def get_prop_samples(dbf, comps, phase_name, desired_data):
         # add everything to the calculate_dict
         calculate_dict['P'] = np.concatenate([calculate_dict['P'], P])
         calculate_dict['T'] = np.concatenate([calculate_dict['T'], T])
-        print(points.shape)
-        print(points)
         calculate_dict['points'] = np.concatenate([calculate_dict['points'], np.repeat(points, len(T)/points.shape[0], axis=0)], axis=0)
         calculate_dict['values'] = np.concatenate([calculate_dict['values'], values.flatten()])
 
@@ -223,7 +221,6 @@ def calculate_thermochemical_error(dbf, comps, phases, datasets, parameters=None
                 calculate_dict['output'] = prop
                 params = parameters
             sample_values = calculate_dict.pop('values')
-            print(calculate_dict)
             results = calculate(dbf, comps, phase_name, broadcast=False, parameters=params, model=phase_models, massfuncs=massfuncs,
                                 callables=callables, **calculate_dict)[calculate_dict['output']].values
             weight = (property_prefix_weight_factor[prop.split('_')[0]]*np.abs(np.mean(sample_values)))**(-1.0)

--- a/espei/error_functions/thermochemical_error.py
+++ b/espei/error_functions/thermochemical_error.py
@@ -45,15 +45,12 @@ def calculate_points_array(phase_constituents, configuration, occupancies=None):
     # construct the points array from zeros
     points = np.zeros(sum(len(subl) for subl in phase_constituents))
     current_subl_idx = 0  # index that marks the beginning of the sublattice
-    for phase_subl, config_subl, subl_occupancies in zip(phase_constituents,
-                                                         configuration,
-                                                         occupancies):
+    for phase_subl, config_subl, subl_occupancies in zip(phase_constituents, configuration, occupancies):
         phase_subl = list(phase_subl)
         if isinstance(config_subl, (tuple, list)):
             # we have mixing on the sublattice
             for comp, comp_occupancy in zip(config_subl, subl_occupancies):
-                points[
-                    current_subl_idx + phase_subl.index(comp)] = comp_occupancy
+                points[current_subl_idx + phase_subl.index(comp)] = comp_occupancy
         else:
             points[current_subl_idx + phase_subl.index(config_subl)] = 1
         current_subl_idx += len(phase_subl)
@@ -146,7 +143,9 @@ def get_prop_samples(dbf, comps, phase_name, desired_data):
         # add everything to the calculate_dict
         calculate_dict['P'] = np.concatenate([calculate_dict['P'], P])
         calculate_dict['T'] = np.concatenate([calculate_dict['T'], T])
-        calculate_dict['points'] = np.concatenate([calculate_dict['points'], points], axis=0)
+        print(points.shape)
+        print(points)
+        calculate_dict['points'] = np.concatenate([calculate_dict['points'], np.repeat(points, len(T)/points.shape[0], axis=0)], axis=0)
         calculate_dict['values'] = np.concatenate([calculate_dict['values'], values.flatten()])
 
     return calculate_dict
@@ -224,6 +223,7 @@ def calculate_thermochemical_error(dbf, comps, phases, datasets, parameters=None
                 calculate_dict['output'] = prop
                 params = parameters
             sample_values = calculate_dict.pop('values')
+            print(calculate_dict)
             results = calculate(dbf, comps, phase_name, broadcast=False, parameters=params, model=phase_models, massfuncs=massfuncs,
                                 callables=callables, **calculate_dict)[calculate_dict['output']].values
             weight = (property_prefix_weight_factor[prop.split('_')[0]]*np.abs(np.mean(sample_values)))**(-1.0)

--- a/espei/tests/test_error_functions.py
+++ b/espei/tests/test_error_functions.py
@@ -6,10 +6,10 @@ import numpy as np
 
 from pycalphad import Database
 
-from espei.error_functions import calculate_activity_error
+from espei.error_functions import calculate_activity_error, calculate_thermochemical_error
 
 from .fixtures import datasets_db
-from .testing_data import CU_MG_TDB, CU_MG_EXP_ACTIVITY
+from .testing_data import CU_MG_TDB, CU_MG_EXP_ACTIVITY, CU_MG_HM_FORM_T_CUMG2, CU_MG_SM_FORM_T_X_FCC_A1
 
 
 def test_activity_error(datasets_db):
@@ -20,3 +20,22 @@ def test_activity_error(datasets_db):
     dbf = Database(CU_MG_TDB)
     error = calculate_activity_error(dbf, ['CU','MG','VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {}, {}, {}, {})
     assert np.isclose(float(error), -93037371.27, atol=0.01)
+
+
+def test_thermochemical_error_with_multiple_T_points(datasets_db):
+    """Multiple temperature datapoints in a dataset for a stoichiometric comnpound should be successful."""
+    datasets_db.insert(CU_MG_HM_FORM_T_CUMG2)
+
+    dbf = Database(CU_MG_TDB)
+    error = calculate_thermochemical_error(dbf, ['CU','MG','VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {})
+    assert np.isclose(float(error), 0, atol=0.01)
+
+
+def test_thermochemical_error_with_multiple_T_X_points(datasets_db):
+    """Multiple temperature and composition datapoints in a dataset for a mixing phase should be successful."""
+    datasets_db.insert(CU_MG_SM_FORM_T_X_FCC_A1)
+
+    dbf = Database(CU_MG_TDB)
+    error = calculate_thermochemical_error(dbf, ['CU', 'MG', 'VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {})
+    assert np.isclose(float(error), 0, atol=0.01)
+

--- a/espei/tests/test_error_functions.py
+++ b/espei/tests/test_error_functions.py
@@ -9,7 +9,7 @@ from pycalphad import Database
 from espei.error_functions import calculate_activity_error, calculate_thermochemical_error
 
 from .fixtures import datasets_db
-from .testing_data import CU_MG_TDB, CU_MG_EXP_ACTIVITY, CU_MG_HM_FORM_T_CUMG2, CU_MG_SM_FORM_T_X_FCC_A1
+from .testing_data import *
 
 
 def test_activity_error(datasets_db):
@@ -22,13 +22,22 @@ def test_activity_error(datasets_db):
     assert np.isclose(float(error), -93037371.27, atol=0.01)
 
 
+def test_thermochemical_error_with_multiple_X_points(datasets_db):
+    """Multiple composition datapoints in a dataset for a mixing phase should be successful."""
+    datasets_db.insert(CU_MG_CPM_FORM_X_HCP_A3)
+
+    dbf = Database(CU_MG_TDB)
+    error = calculate_thermochemical_error(dbf, ['CU','MG','VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {})
+    assert np.isclose(float(error), -520.0, atol=0.01)
+
+
 def test_thermochemical_error_with_multiple_T_points(datasets_db):
     """Multiple temperature datapoints in a dataset for a stoichiometric comnpound should be successful."""
     datasets_db.insert(CU_MG_HM_FORM_T_CUMG2)
 
     dbf = Database(CU_MG_TDB)
     error = calculate_thermochemical_error(dbf, ['CU','MG','VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {})
-    assert np.isclose(float(error), 0, atol=0.01)
+    assert np.isclose(float(error), -85852620.13414142, atol=0.01)
 
 
 def test_thermochemical_error_with_multiple_T_X_points(datasets_db):
@@ -37,5 +46,5 @@ def test_thermochemical_error_with_multiple_T_X_points(datasets_db):
 
     dbf = Database(CU_MG_TDB)
     error = calculate_thermochemical_error(dbf, ['CU', 'MG', 'VA'], list(dbf.phases.keys()), datasets_db, {}, {}, {}, {})
-    assert np.isclose(float(error), 0, atol=0.01)
+    assert np.isclose(float(error), -31241.312055519393, atol=0.01)
 

--- a/espei/tests/testing_data.py
+++ b/espei/tests/testing_data.py
@@ -197,3 +197,31 @@ CU_MG_SM_FORM_T_X_FCC_A1 = yaml.load("""{
   "comment": "FAKE DATA"
 }
 """)
+
+
+CU_MG_CPM_FORM_X_HCP_A3 = yaml.load("""{
+  "components": ["CU", "MG", "VA"],
+  "phases": ["HCP_A3"],
+  "solver": {
+    "sublattice_site_ratios": [1, 1],
+    "sublattice_occupancies": [
+    [[0.5, 0.5], 1],
+    [[0.1, 0.9], 1]
+    ],
+    "sublattice_configurations": [
+    [["CU", "MG"], "VA"],
+    [["CU", "MG"], "VA"]
+    ],
+    "mode": "manual"
+  },
+  "conditions": {
+    "P": 101325,
+    "T": 300,
+  },
+
+  "output": "CPM_FORM",
+    "values":   [[[10, 15]]],
+  "reference": "FAKE DATA",
+  "comment": "FAKE DATA"
+}
+""")

--- a/espei/tests/testing_data.py
+++ b/espei/tests/testing_data.py
@@ -148,3 +148,52 @@ CU_MG_EXP_ACTIVITY = yaml.load("""{
   "comment": "Digitized Figure "
 }
 """)
+
+
+CU_MG_HM_FORM_T_CUMG2 = yaml.load("""{
+  "components": ["CU", "MG", "VA"],
+  "phases": ["CUMG2"],
+  "solver": {
+    "sublattice_site_ratios": [1, 2],
+    "sublattice_configurations": [["CU", "MG"]],
+    "mode": "manual"
+  },
+  "conditions": {
+    "P": 101325,
+    "T": [300, 400],
+  },
+
+  "output": "HM_FORM",
+    "values":   [[[10], [100]]],
+  "reference": "FAKE DATA",
+  "comment": "FAKE DATA"
+}
+""")
+
+
+CU_MG_SM_FORM_T_X_FCC_A1 = yaml.load("""{
+  "components": ["CU", "MG", "VA"],
+  "phases": ["FCC_A1"],
+  "solver": {
+    "sublattice_site_ratios": [1, 1],
+    "sublattice_occupancies": [
+    [[0.5, 0.5], 1],
+    [[0.1, 0.9], 1]
+    ],
+    "sublattice_configurations": [
+    [["CU", "MG"], "VA"],
+    [["CU", "MG"], "VA"]
+    ],
+    "mode": "manual"
+  },
+  "conditions": {
+    "P": 101325,
+    "T": [300, 400],
+  },
+
+  "output": "SM_FORM",
+    "values":   [[[10, 50], [100, 500]]],
+  "reference": "FAKE DATA",
+  "comment": "FAKE DATA"
+}
+""")


### PR DESCRIPTION

* FIX: Fix incorrectly sized pycalphad P/T/points arrays for MCMC thermochemical error
* TST: Includes tests for 3 datasets with varying X, T, T and X
* FIX: Fix error where SymPy NaNs in calculate_activity_error would raise in emcee (convert them the NumPy NaNs)