### PR TITLE
FIX: Update to use dask>=0.18

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,8 +13,8 @@ Therefore it is suggested to install ESPEI from conda-forge.
     conda install -c pycalphad -c msys2 -c conda-forge --yes espei
 
 After installation, you must turn off dask's work stealing.
-Change the work stealing setting to ``work-stealing: False`` in ``~/.dask/config.yaml``.
-See the `dask-distributed documentation <https://distributed.readthedocs.io/en/latest/configuration.html>`_ for more.
+Change the work stealing setting to ``distributed.scheduler.work-stealing: False`` in ``~/.config/dask/distributed.yaml``.
+See configuration_ below for more details.
 
 PyPI
 ----
@@ -28,8 +28,8 @@ dependency of `Ipopt <https://projects.coin-or.org/Ipopt>`_.
     pip install espei
 
 After installation, you must turn off dask's work stealing.
-Change the work stealing setting to ``work-stealing: False`` in ``~/.dask/config.yaml``.
-See the `dask-distributed documentation <https://distributed.readthedocs.io/en/latest/configuration.html>`_ for more.
+Change the work stealing setting to ``distributed.scheduler.work-stealing: False`` in ``~/.config/dask/distributed.yaml``.
+See configuration_ below for more details.
 
 Development versions
 --------------------
@@ -50,5 +50,26 @@ ESPEI package, and replaces it with the package from GitHub.
 Upgrading ESPEI later requires you to run ``git pull`` in this directory.
 
 After installation, you must turn off dask's work stealing.
-Change the work stealing setting to ``work-stealing: False`` in ``~/.dask/config.yaml``.
+Change the work stealing setting to ``distributed.scheduler.work-stealing: False`` in ``~/.config/dask/distributed.yaml``.
+See configuration_ below for more details.
+
+.. _configuration:
+
+Configuration
+-------------
+
+ESPEI uses dask-distributed to parallelize ESPEI.
+
+After installation, you must turn off dask's work stealing!
+Change the file at ``~/.config/dask/distributed.yaml`` to look something like:
+
+
+.. code-block:: YAML
+
+   distributed:
+     version: 2
+     scheduler:
+       work-stealing: False
+
+
 See the `dask-distributed documentation <https://distributed.readthedocs.io/en/latest/configuration.html>`_ for more.

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -48,7 +48,7 @@ def _raise_dask_work_stealing():
     import distributed
     has_work_stealing = distributed.config['distributed']['scheduler']['work-stealing']
     if has_work_stealing:
-        raise ValueError("The parameter 'work-stealing' is on in dask. Enabling this parameter causes some instability. Set 'distributed.scheduler.work-stealing: False' in your '~/.config/distributed.yaml' file. See the example at http://espei.org/en/latest/installation.html#configuration for more.")
+        raise ValueError("The parameter 'work-stealing' is on in dask. Enabling this parameter causes some instability. Set 'distributed.scheduler.work-stealing: False' in your '~/.config/dask/distributed.yaml' file. See the example at http://espei.org/en/latest/installation.html#configuration for more.")
 
 
 def get_run_settings(input_dict):

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -46,9 +46,9 @@ def _raise_dask_work_stealing():
 
     """
     import distributed
-    has_work_stealing = distributed.config.get('work-stealing', True)
+    has_work_stealing = distributed.config['distributed']['scheduler']['work-stealing']
     if has_work_stealing:
-        raise ValueError("The parameter 'work-stealing' is on in dask. Enabling this parameter causes some instability. Set 'work-stealing: False' in your '~/.dask/config.yaml' file. See http://distributed.readthedocs.io/en/latest/configuration.html for more.")
+        raise ValueError("The parameter 'work-stealing' is on in dask. Enabling this parameter causes some instability. Set 'distributed.scheduler.work-stealing: False' in your '~/.config/distributed.yaml' file. See the example at http://espei.org/en/latest/installation.html#configuration for more.")
 
 
 def get_run_settings(input_dict):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'numpy',
         'scipy',
         'six',
-        'dask[complete]>=0.15',
+        'dask[complete]>=0.18',
         'distributed',
         'tinydb>=3',
         'scikit-learn',


### PR DESCRIPTION
In version 0.18, dask updated the configuration file. This change supports the new version of dask and distributed, checking the work-stealing correctly.

Closes #66 