### PR TITLE
MAINT: Improve input consistency

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -115,5 +115,5 @@ Info (``logging.info``)
 Debug (``logging.debug``)
   Debugging is the lowest level of logging we provide in ESPEI.
   Debug messages should consist of possibly useful information that is beyond the user's direct control.
-  Examples are the values of initial parameters, progress of checking datasets and building phase models, and the acceptance ratios of MCMC steps.
+  Examples are the values of initial parameters, progress of checking datasets and building phase models, and the acceptance ratios of MCMC iterations.
 

--- a/docs/cu-mg-example.rst
+++ b/docs/cu-mg-example.rst
@@ -226,7 +226,7 @@ the following structure
       phase_models: Cu-Mg-input.json
       datasets: input-data
     mcmc:
-      mcmc_steps: 1000
+      iterations: 1000
       input_db: cu-mg_dft.tdb
     output:
       output_db: cu-mg_mcmc.tdb
@@ -243,7 +243,7 @@ Note that you may also see messages about convergence failures or about
 droppping conditions. These refer to failures to calculate the log-probability
 or in the pycalphad solver's equilibrium calculation. They are not detrimental
 to the optimization accuracy, but overall optimization may be slower because
-those parameter steps will never be accepted (they return a log-probability of
+those parameter proposals will never be accepted (they return a log-probability of
 :math:`-\infty`).
 
 Finally, we can use the newly optimized database to plot the phase diagram
@@ -287,7 +287,7 @@ are serialized NumPy arrays. The file names are set in your
 ``espei-in.yaml`` file. The filenames are set by ``output.tracefile``
 and ``output.probfile``
 (`documentation <http://espei.org/en/latest/writing_input.html#tracefile>`__)
-and the defaults are ``chain.npy`` and ``lnprob.npy``, respectively.
+and the defaults are ``trace.npy`` and ``lnprob.npy``, respectively.
 
 The ``tracefile`` contains all of the parameters that were proposed over
 all chains and iterations (the trace). The ``probfile`` contains all of
@@ -314,7 +314,7 @@ after 115 iterations.
     import numpy as np
     from espei.analysis import truncate_arrays
 
-    trace = np.load('chain.npy')
+    trace = np.load('trace.npy')
     lnprob = np.load('lnprob.npy')
 
     trace, lnprob = truncate_arrays(trace, lnprob)
@@ -352,7 +352,7 @@ parameters explore the space and converge to a solution.
 
     from espei.analysis import truncate_arrays
 
-    trace = np.load('chain.npy')
+    trace = np.load('trace.npy')
     lnprob = np.load('lnprob.npy')
 
     trace, lnprob = truncate_arrays(trace, lnprob)
@@ -405,7 +405,7 @@ similar error.
 
     from espei.analysis import truncate_arrays
 
-    trace = np.load('chain.npy')
+    trace = np.load('trace.npy')
     lnprob = np.load('lnprob.npy')
 
     trace, lnprob = truncate_arrays(trace, lnprob)

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -32,7 +32,7 @@ Here is an example for multiphase fitting starting from a generated TDB with a s
       phase_models: my-phases.json
       datasets: my-input-data
     mcmc:
-      mcmc_steps: 1000
+      iterations: 1000
       input_db: my-tdb.tdb
       scheduler: my-scheduler.json
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ You will need single-phase and multi-phase data for a full run.
 Fit settings and all datasets are stored as JSON files and described in detail at the :ref:`Input data` page.
 All of your input datasets should be validated by running ``espei --check-datasets my-input-datasets``, where ``my-input-datasets`` is a folder of all your JSON files.
 
-The main output result is going to be a database (defaults to ``out.tdb``), an array of the steps in the MCMC chain (defaults to ``chain.npy``), and the an array of the log-probabilities for each iteration and chain (defaults to ``lnprob.npy``).
+The main output result is going to be a database (defaults to ``out.tdb``), an array of the steps in the MCMC trace (defaults to ``trace.npy``), and the an array of the log-probabilities for each iteration and chain (defaults to ``lnprob.npy``).
 
 Single-phase only
 -----------------
@@ -47,7 +47,7 @@ If you have a database already and just want to do a multi-phase fitting, you ca
       phase_models: my-phases.json
       datasets: my-input-data
     mcmc:
-      mcmc_steps: 1000
+      iterations: 1000
       input_db: my-tdb.tdb
 
 The TDB file you input must have all of the degrees of freedom you want as FUNCTIONs with names beginning with ``VV``.
@@ -55,7 +55,7 @@ The TDB file you input must have all of the degrees of freedom you want as FUNCT
 Restart from previous run-phase only
 ------------------------------------
 
-If you've run an MCMC fitting already in ESPEI and have a chain file called ``my-previous-chain.npy`` , then you can resume the calculation with the following input file
+If you've run an MCMC fitting already in ESPEI and have a trace file called ``my-previous-trace.npy`` , then you can resume the calculation with the following input file
 
 .. code-block:: yaml
 
@@ -63,9 +63,9 @@ If you've run an MCMC fitting already in ESPEI and have a chain file called ``my
       phase_models: my-phases.json
       datasets: my-input-data
     mcmc:
-      mcmc_steps: 1000
+      iterations: 1000
       input_db: my-tdb.tdb
-      restart_chain: my-previous-chain.npy
+      restart_trace: my-previous-trace.npy
 
 
 Full run
@@ -107,7 +107,7 @@ Run ``espei check-datasets my-input-datasets`` on your directory ``my-input-data
 Q: How do I analyze my results?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A: By default, ESPEI will create ``chain.npy`` and ``lnprob.npy`` for the MCMC chain at the end of your run and according to the save interval (defaults to every 20 iterations).
+A: By default, ESPEI will create ``trace.npy`` and ``lnprob.npy`` for the MCMC chain at the specified save interval and according to the save interval (defaults to ever iteration).
 These are created from arrays via ``numpy.save()`` and can thus be loaded with ``numpy.load()``.
 Note that the arrays are preallocated with zeros.
 These filenames and settings can be changed using in the input file.

--- a/docs/writing_input.rst
+++ b/docs/writing_input.rst
@@ -43,8 +43,8 @@ All of the possible keys are
      ref_state
 
    mcmc:
-     mcmc_steps
-     mcmc_save_interval
+     iterations
+     save_interval
      cores
      scheduler
      input_db
@@ -119,7 +119,7 @@ tracefile
 Name of the file that the MCMC trace is written to.
 The array has shape ``(number of chains, iterations, number of parameters)``.
 
-The array is preallocated and padded with zeros, so if you selected to take 2000 MCMC steps, but only got through 1500, the last 500 values would be all 0.
+The array is preallocated and padded with zeros, so if you selected to take 2000 MCMC iterations, but only got through 1500, the last 500 values would be all 0.
 
 You must choose a unique file name.
 An error will be raised if file specified by ``tracefile`` already exists.
@@ -133,7 +133,7 @@ probfile
 Name of the file that the MCMC ln probabilities are written to.
 The array has shape ``(number of chains, iterations)``.
 
-The array is preallocated and padded with zeros, so if you selected to take 2000 MCMC steps, but only got through 1500, the last 500 values would be all 0.
+The array is preallocated and padded with zeros, so if you selected to take 2000 MCMC iterations, but only got through 1500, the last 500 values would be all 0.
 
 You must choose a unique file name.
 An error will be raised if file specified by ``probfile`` already exists.
@@ -183,7 +183,7 @@ The parameters can come from including a ``generate_parameters`` step, or by spe
 
 If you choose to use the parameters from a database, you can then further control settings based on whether it is the first MCMC run for a system (you are starting fresh) or whether you are continuing from a previous run (a 'restart').
 
-mcmc_steps
+iterations
 ----------
 
 :type: int
@@ -193,14 +193,14 @@ Number of iterations to perform in emcee.
 Each iteration consists of accepting one step for each chain in the ensemble.
 
 
-mcmc_save_interval
-------------------
+save_interval
+-------------
 
 :type: int
 :default: 1
 
-Controls the interval (in number of steps) for saving the MCMC chain and probability files.
-By default, new files will be written out every step. For large files (many mcmc steps and chains per parameter),
+Controls the interval (in number of iterations) for saving the MCMC chain and probability files.
+By default, new files will be written out every iteration. For large files (many mcmc iterations and chains per parameter),
 these might become expensive to write out to disk.
 
 cores
@@ -305,13 +305,13 @@ ESPEI with the same Database and initial settings (either the same
 
 Starting two runs with the same TDB or with parameter generation
 (which is deterministic) will result in the chains being at exactly
-the same position after 100 steps. If these are both restarted after
-100 steps for another 50 steps, then the final chain after 150 steps
+the same position after 100 iterations. If these are both restarted after
+100 iterations for another 50 iterations, then the final chain after 150 iterations
 will be the same.
 
 It is important to note that this is only explictly True when
 *starting* at the same point. If Run 1 and Run 2 are started with the
-same initial parameters and Run 1 proceeds 50 steps while Run 2
-proceeds 100 steps, restarting Run 1 for 100 steps and Run 2 for 50
-steps (so they are both at 150 total steps) will **NOT** give the same
+same initial parameters and Run 1 proceeds 50 iterations while Run 2
+proceeds 100 iterations, restarting Run 1 for 100 iterations and Run 2 for 50
+iterations (so they are both at 150 total iterations) will **NOT** give the same
 result.

--- a/espei/analysis.py
+++ b/espei/analysis.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def truncate_arrays(trace_array, prob_array=None):
     """
-    Return slides of ESPEI output arrays with any empty remaining steps (zeros) removed.
+    Return slides of ESPEI output arrays with any empty remaining iterations (zeros) removed.
 
     Parameters
     ----------

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -74,9 +74,9 @@ def get_run_settings(input_dict):
     ValueError
     """
     run_settings = schema.normalized(input_dict)
-    # can't have chain_std_deviation and chains_per_parameters defaults with restart_chain
+    # can't have chain_std_deviation and chains_per_parameter defaults with restart_trace
     if run_settings.get('mcmc') is not None:
-            if run_settings['mcmc'].get('restart_chain') is None:
+            if run_settings['mcmc'].get('restart_trace') is None:
                 run_settings['mcmc']['chains_per_parameter'] = run_settings['mcmc'].get('chains_per_parameter', 2)
                 run_settings['mcmc']['chain_std_deviation'] = run_settings['mcmc'].get('chain_std_deviation', 0.1)
     if not schema.validate(run_settings):
@@ -168,25 +168,25 @@ def run_espei(run_settings):
         if mcmc_settings.get('input_db'):
             dbf = Database(mcmc_settings.get('input_db'))
 
-        # load the restart chain if needed
-        if mcmc_settings.get('restart_chain'):
-            restart_chain = np.load(mcmc_settings.get('restart_chain'))
+        # load the restart trace if needed
+        if mcmc_settings.get('restart_trace'):
+            restart_trace = np.load(mcmc_settings.get('restart_trace'))
         else:
-            restart_chain = None
+            restart_trace = None
 
         # load the remaning mcmc fitting parameters
-        mcmc_steps = mcmc_settings.get('mcmc_steps')
-        save_interval = mcmc_settings.get('mcmc_save_interval')
+        iterations = mcmc_settings.get('iterations')
+        save_interval = mcmc_settings.get('save_interval')
         chains_per_parameter = mcmc_settings.get('chains_per_parameter')
         chain_std_deviation = mcmc_settings.get('chain_std_deviation')
         deterministic = mcmc_settings.get('deterministic')
 
-        dbf, sampler = mcmc_fit(dbf, datasets, scheduler=client, mcmc_steps=mcmc_steps,
+        dbf, sampler = mcmc_fit(dbf, datasets, scheduler=client, iterations=iterations,
                                 chains_per_parameter=chains_per_parameter,
                                 chain_std_deviation=chain_std_deviation,
                                 save_interval=save_interval,
                                 tracefile=tracefile, probfile=probfile,
-                                restart_chain=restart_chain,
+                                restart_trace=restart_trace,
                                 deterministic=deterministic,
                                 )
 

--- a/espei/input-schema.yaml
+++ b/espei/input-schema.yaml
@@ -23,7 +23,7 @@ output:
     output_db:
       type: string
       default: out.tdb
-    tracefile: # name of the file containing the mcmc chain array
+    tracefile: # name of the file containing the mcmc trace array
       type: string
       default: trace.npy
       regex: '.*\.npy$'
@@ -50,18 +50,18 @@ generate_parameters:
 ## Parameters can come from
 ##   1. a preceding generate_parameters step
 ##   2. by generating chains from a previous input_db
-##   3. by using chains from a restart_chain for phases in an input_db
+##   3. by using chains from a restart_trace for phases in an input_db
 mcmc:
   type: dict
   oneof_dependencies:
     - 'mcmc.input_db'
     - 'generate_parameters'
   schema:
-    mcmc_steps:
+    iterations:
       type: integer
       min: 1
       required: True
-    mcmc_save_interval:
+    save_interval:
       type: integer
       default: 1
       min: 1
@@ -76,7 +76,7 @@ mcmc:
       min: 1
     input_db: # TDB file used to start the mcmc run
       type: string
-    restart_chain: # restart the mcmc fitting from a previous calculation
+    restart_trace: # restart the mcmc fitting from a previous calculation
       type: string
       dependencies: input_db
       regex: '.*\.npy$'
@@ -86,12 +86,12 @@ mcmc:
       min: 2
       allof:
         - required: True
-        - excludes: restart_chain
+        - excludes: restart_trace
     chain_std_deviation: # fraction of a parameter for the standard deviation in the walkers
       min: 0
       allof:
         - required: True
-        - excludes: restart_chain
+        - excludes: restart_trace
     deterministic:
       type: boolean
       default: True

--- a/espei/tests/test_schema.py
+++ b/espei/tests/test_schema.py
@@ -12,7 +12,7 @@ FULL_RUN_DICT = {
         },
     'mcmc':
         {
-            'mcmc_steps': 1000
+            'iterations': 1000
         },
     'system':
         {
@@ -37,7 +37,7 @@ GEN_PARAMS_DICT = {
 MCMC_RUN_DICT = {
     'mcmc':
         {
-            'mcmc_steps': 1000,
+            'iterations': 1000,
             'input_db': 'input.tdb',
         },
     'system':
@@ -50,9 +50,9 @@ MCMC_RUN_DICT = {
 MCMC_RESTART_DICT = {
     'mcmc':
         {
-            'mcmc_steps': 1000,
+            'iterations': 1000,
             'input_db': 'input.tdb',
-            'restart_chain': 'restart_chain.npy'
+            'restart_trace': 'restart_trace.npy'
         },
     'system':
         {
@@ -64,7 +64,7 @@ MCMC_RESTART_DICT = {
 MCMC_NO_INPUT_DICT = {
     'mcmc':
         {
-            'mcmc_steps': 1000
+            'iterations': 1000
         },
     'system':
         {
@@ -80,7 +80,7 @@ MCMC_OVERSPECIFIED_INPUT_DICT = {
         },
     'mcmc':
         {
-            'mcmc_steps': 1000,
+            'iterations': 1000,
             'input_db': 'my_input.db'
         },
     'system':
@@ -134,7 +134,7 @@ def test_correct_defaults_are_applied_from_minimal_specification():
     assert d['output']['output_db'] == 'out.tdb'
     assert d['output']['tracefile'] == 'trace.npy'
     assert d['output']['probfile'] == 'lnprob.npy'
-    assert d['mcmc']['mcmc_save_interval'] == 1
+    assert d['mcmc']['save_interval'] == 1
     assert d['mcmc']['scheduler'] == 'dask'
     assert d['mcmc']['chains_per_parameter'] == 2
     assert d['mcmc']['chain_std_deviation'] == 0.1


### PR DESCRIPTION
Input and internal ESPEI APIs were often confused whether to call the MCMC trace of chains, iterations and parameters a "chain" or a "trace".

This commit makes it so that every time we are talking about all the chains together, we refer to it as the "trace", but when we refer to an individual chain the trace, we call it a "chain".

Additionally, the "mcmc.mcmc_steps" was renamed to "mcmc.iterations" to avoid redundancy and improve clarity. "mcmc.mcmc_save_interval" was similarly updated to "save_interval".

The input file, docs and Python API all reflect these changes.