### PR TITLE
ENH: Optimize ZPF error calculation and provide an approximate ZPF driving force

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy=1.5.1' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then cd pycalphad-dev; fi
-  - if [[ $PYCALPHAD_DEVELOP ]]; then pip install --no-deps -e . ; fi
+  - if [[ $PYCALPHAD_DEVELOP ]]; then pip install -e . ; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then cd .. ; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy>=1.2' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy=1.5.1' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -58,7 +58,8 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
     import time
     t1 = time.time()
     phases = sorted(dbf.phases.keys())
-    models = instantiate_models(dbf, comps, phases, parameters=dict(zip(symbols_to_fit, [0]*len(symbols_to_fit))))
+    parameters = dict(zip(symbols_to_fit, [0]*len(symbols_to_fit)))
+    models = instantiate_models(dbf, comps, phases, parameters=parameters)
     if make_callables:
         eq_callables = build_callables(dbf, comps, phases, models, parameter_symbols=symbols_to_fit,
                             output='GM', build_gradients=True, build_hessians=True,
@@ -74,8 +75,7 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
     error_context = {
         'symbols_to_fit': symbols_to_fit,
         'zpf_kwargs': {
-            'dbf': dbf, 'phases': phases, 'zpf_data': get_zpf_data(comps, phases, datasets),
-            'phase_models': models, 'callables': eq_callables,
+            'zpf_data': get_zpf_data(dbf, comps, phases, datasets, parameters),
             'data_weight': data_weights.get('ZPF', 1.0),
         },
         'thermochemical_kwargs': {

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -64,9 +64,9 @@ def extract_phases_comps(phase_region):
     region_comp_conds = []
     phase_flags = []
     for tie_point in phase_region:
-        if len(tie_point) == 4: # phase_flag within
+        if len(tie_point) == 4:  # phase_flag within
             phase_name, components, compositions, flag = tie_point
-        elif len(tie_point) == 3: # no phase_flag within
+        elif len(tie_point) == 3:  # no phase_flag within
             phase_name, components, compositions = tie_point
             flag = None
         else:
@@ -86,7 +86,7 @@ PhaseRegion = NamedTuple('PhaseRegion', (('region_phases', Sequence[str]),
                                          ('phases', Sequence[str]),
                                          ('models', Dict[str, Model]),
                                          ('phase_records', Sequence[Dict[str, PhaseRecord]]),
-                                        ))
+                                         ))
 
 
 def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float]):

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -181,7 +181,7 @@ def estimate_hyperplane(phase_region: PhaseRegion, parameters: np.ndarray) -> np
             # Note that we consider all phases in the system, not just ones in this tie region
             str_statevar_dict = OrderedDict([(str(key),cond_dict[key]) for key in sorted(phase_region.potential_conds.keys(), key=str)])
             grid = calculate_(dbf, species, phases, str_statevar_dict, models, phase_records, pdens=500, fake_points=True)
-            multi_eqdata = equilibrium_(species, phase_records, cond_dict, grid)
+            multi_eqdata = no_op_equilibrium_(species, phase_records, cond_dict, grid)
             target_hyperplane_phases.append(multi_eqdata.Phase.squeeze())
             # Does there exist only a single phase in the result with zero internal degrees of freedom?
             # We should exclude those chemical potentials from the average because they are meaningless.
@@ -242,7 +242,7 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
     else:
         # Extract energies from single-phase calculations
         grid = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=500, fake_points=True)
-        single_eqdata = equilibrium_(species, phase_records, cond_dict, grid)
+        single_eqdata = no_op_equilibrium_(species, phase_records, cond_dict, grid)
         if np.all(np.isnan(single_eqdata.NP)):
             logging.debug('Calculation failure: all NaN phases with phases: {}, conditions: {}, parameters {}'.format(current_phase, cond_dict, parameters))
             return np.inf

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -16,12 +16,18 @@ composition conditions to calculate chemical potentials at.
 
 import operator, logging
 from collections import defaultdict, OrderedDict
+from typing import Sequence, Dict, NamedTuple, Any
 
 import numpy as np
 from scipy.stats import norm
 import tinydb
 
-from pycalphad import calculate, equilibrium, variables as v
+from pycalphad import Database, calculate, equilibrium, Model, variables as v
+from pycalphad.codegen.callables import build_phase_records
+from pycalphad.core.utils import instantiate_models
+from pycalphad.core.phase_rec import PhaseRecord
+from espei.utils import PickleableTinyDB
+from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_
 
 def _safe_index(items, index):
     try:
@@ -29,8 +35,60 @@ def _safe_index(items, index):
     except IndexError:
         return None
 
+def update_phase_record_parameters(phase_records: Dict[str, PhaseRecord], parameters: np.ndarray) -> None:
+    for phase_name, phase_record in phase_records.items():
+        phase_record.parameters[:] = parameters
 
-def get_zpf_data(comps, phases, datasets):
+def extract_conditions(all_conditions: Dict[v.StateVariable, np.ndarray], idx: int) -> Dict[v.StateVariable, float]:
+    """Conditions are either scalar or 1d arrays for the conditions in the entire dataset.
+    This function extracts the condition corresponding to the current region,
+    based on the index in the 1d condition array.
+    """
+    pot_conds = {}  # e.g. v.P, v.T
+    for cond_key, cond_val in all_conditions.items():
+        cond_val = np.atleast_1d(np.asarray(cond_val))
+        # If the conditions is an array, we want the corresponding value
+        # Otherwise treat it as a scalar
+        if len(cond_val) > 1:
+            cond_val = cond_val[idx]
+        pot_conds[getattr(v, cond_key)] = float(cond_val)
+    return pot_conds
+
+
+def extract_phases_comps(phase_region):
+    """Extract the phase names, phase compositions and any phase flags from
+    each tie-line point in the phase region
+    """
+    region_phases = []
+    region_comp_conds = []
+    phase_flags = []
+    for tie_point in phase_region:
+        if len(tie_point) == 4: # phase_flag within
+            phase_name, components, compositions, flag = tie_point
+        elif len(tie_point) == 3: # no phase_flag within
+            phase_name, components, compositions = tie_point
+            flag = None
+        else:
+            raise ValueError("Wrong number of data in tie-line point")
+        region_phases.append(phase_name)
+        region_comp_conds.append(dict(zip(map(v.X, map(lambda x: x.upper(), components)), compositions)))
+        phase_flags.append(flag)
+    return region_phases, region_comp_conds, phase_flags
+
+
+PhaseRegion = NamedTuple('PhaseRegion', (('region_phases', Sequence[str]),
+                                         ('potential_conds', Dict[v.StateVariable, float]),
+                                         ('comp_conds', Sequence[Dict[v.Composition, float]]),
+                                         ('phase_flags', Sequence[str]),
+                                         ('dbf', Database),
+                                         ('species', Sequence[v.Species]),
+                                         ('phases', Sequence[str]),
+                                         ('models', Dict[str, Model]),
+                                         ('phase_records', Sequence[Dict[str, PhaseRecord]]),
+                                        ))
+
+
+def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float]):
     """
     Return the ZPF data used in the calculation of ZPF error
 
@@ -54,34 +112,33 @@ def get_zpf_data(comps, phases, datasets):
                                    (tinydb.where('components').test(lambda x: set(x).issubset(comps))) &
                                    (tinydb.where('phases').test(lambda x: len(set(phases).intersection(x)) > 0)))
 
-    zpf_data = []
+    zpf_data = []  # 1:1 correspondence with each dataset
     for data in desired_data:
-        payload = data['values']
+        data_comps = list(set(data['components']).union({'VA'}))
+        species = sorted(map(v.Species, data_comps), key=str)
+        models = instantiate_models(dbf, species, phases, parameters=parameters)
+        all_regions = data['values']
         conditions = data['conditions']
-        # create a dictionary of each set of phases containing a list of individual points on the tieline
-        # individual tieline points are tuples of (conditions, {composition dictionaries})
-        phase_regions = defaultdict(lambda: list())
-        # TODO: Fix to only include equilibria listed in 'phases'
-        for idx, p in enumerate(payload):
-            phase_key = tuple(sorted(rp[0] for rp in p))
-            if len(phase_key) < 2:
+        phase_regions = []
+        # Each phase_region is one set of phases in equilibrium (on a tie-line),
+        # e.g. [["ALPHA", ["B"], [0.25]], ["BETA", ["B"], [0.5]]]
+        for idx, phase_region in enumerate(all_regions):
+            # We need to construct a PhaseRegion by matching up phases/compositions to the conditions
+            if len(phase_region) < 2:
                 # Skip single-phase regions for fitting purposes
                 continue
-            # Need to sort 'p' here so we have the sorted ordering used in 'phase_key'
-            # rp[3] optionally contains additional flags, e.g., "disordered", to help the solver
-            comp_dicts = [(dict(zip([v.X(x.upper()) for x in rp[1]], rp[2])), _safe_index(rp, 3))
-                          for rp in sorted(p, key=operator.itemgetter(0))]
-            cur_conds = {}
-            for key, value in conditions.items():
-                value = np.atleast_1d(np.asarray(value))
-                if len(value) > 1:
-                    value = value[idx]
-                cur_conds[getattr(v, key)] = float(value)
-            phase_regions[phase_key].append((cur_conds, comp_dicts))
+            # Extract the conditions for entire phase region
+            region_potential_conds = extract_conditions(conditions, idx)
+            region_potential_conds[v.N] = region_potential_conds.get(v.N) or 1.0  # Add v.N condition, if missing
+            # Extract all the phases and compositions from the tie-line points
+            region_phases, region_comp_conds, phase_flags = extract_phases_comps(phase_region)
+            region_phase_records = [build_phase_records(dbf, species, phases, {**region_potential_conds, **comp_conds}, models, parameters=parameters, build_gradients=True, build_hessians=True)
+                                    for comp_conds in region_comp_conds]
+            phase_regions.append(PhaseRegion(region_phases, region_potential_conds, region_comp_conds, phase_flags, dbf, species, phases, models, region_phase_records))
 
         data_dict = {
             'weight': data.get('weight', 1.0),
-            'data_comps': list(set(data['components']).union({'VA'})),
+            'data_comps': data_comps,
             'phase_regions': phase_regions,
             'dataset_reference': data['reference']
         }
@@ -89,39 +146,13 @@ def get_zpf_data(comps, phases, datasets):
     return zpf_data
 
 
-def estimate_hyperplane(dbf, comps, phases, current_statevars, comp_dicts, phase_models, parameters, callables=None):
+def estimate_hyperplane(phase_region: PhaseRegion, parameters: np.ndarray) -> np.ndarray:
     """
     Calculate the chemical potentials for the target hyperplane, one vertex at a time
 
-    Parameters
-    ----------
-    dbf : pycalphad.Database
-        Database to consider
-    comps : list
-        List of active component names
-    phases : list
-        List of phases to consider
-    current_statevars : dict
-        Dictionary of state variables, e.g. v.P and v.T, no compositions.
-    comp_dicts : list
-        List of tuples of composition dictionaries and phase flags. Composition
-        dictionaries are pycalphad variable dicts and the flag is a string e.g.
-        ({v.X('CU'): 0.5}, 'disordered')
-    phase_models : dict
-        Phase models to pass to pycalphad calculations
-    parameters : dict
-        Dictionary of symbols that will be overridden in pycalphad.equilibrium
-    callables : dict
-        Callables to pass to pycalphad
-
-    Returns
-    -------
-    numpy.ndarray
-        Array of chemical potentials.
-
     Notes
     -----
-    This takes just *one* set of phase equilibria, e.g. a dataset point of
+    This takes just *one* set of phase equilibria, a phase region, e.g. a dataset point of
     [['FCC_A1', ['CU'], [0.1]], ['LAVES_C15', ['CU'], [0.3]]]
     and calculates the chemical potentials given all the phases possible at the
     given compositions. Then the average chemical potentials of each end point
@@ -130,21 +161,26 @@ def estimate_hyperplane(dbf, comps, phases, current_statevars, comp_dicts, phase
     """
     target_hyperplane_chempots = []
     target_hyperplane_phases = []
-    parameters = OrderedDict(sorted(parameters.items(), key=str))
-    # TODO: unclear whether we use phase_flag and how it would be used. It should be just a 'disordered' kind of flag.
-    for cond_dict, phase_flag in comp_dicts:
+    dbf = phase_region.dbf
+    species = phase_region.species
+    phases = phase_region.phases
+    models = phase_region.models
+    for comp_conds, phase_flag, phase_records in zip(phase_region.comp_conds, phase_region.phase_flags, phase_region.phase_records):
         # We are now considering a particular tie vertex
+        update_phase_record_parameters(phase_records, parameters)
+        cond_dict = {**comp_conds, **phase_region.potential_conds}
         for key, val in cond_dict.items():
             if val is None:
                 cond_dict[key] = np.nan
-        cond_dict.update(current_statevars)
         if np.any(np.isnan(list(cond_dict.values()))):
             # This composition is unknown -- it doesn't contribute to hyperplane estimation
             pass
         else:
             # Extract chemical potential hyperplane from multi-phase calculation
             # Note that we consider all phases in the system, not just ones in this tie region
-            multi_eqdata = equilibrium(dbf, comps, phases, cond_dict, model=phase_models, parameters=parameters, callables=callables, to_xarray=False)
+            str_statevar_dict = OrderedDict([(str(key),cond_dict[key]) for key in sorted(phase_region.potential_conds.keys(), key=str)])
+            grid = calculate_(dbf, species, phases, str_statevar_dict, models, phase_records, pdens=500, fake_points=True)
+            multi_eqdata = equilibrium_(species, phase_records, cond_dict, grid)
             target_hyperplane_phases.append(multi_eqdata.Phase.squeeze())
             # Does there exist only a single phase in the result with zero internal degrees of freedom?
             # We should exclude those chemical potentials from the average because they are meaningless.
@@ -160,47 +196,25 @@ def estimate_hyperplane(dbf, comps, phases, current_statevars, comp_dicts, phase
     return target_hyperplane_mean_chempots
 
 
-def driving_force_to_hyperplane(dbf, comps, current_phase, cond_dict, target_hyperplane_chempots,
-                        phase_flag, phase_models, parameters, callables=None):
+def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: Sequence[str], phase_region: PhaseRegion, vertex_idx: int, parameters: np.ndarray) -> float:
     """Calculate the integrated driving force between the current hyperplane and target hyperplane.
-
-    Parameters
-    ----------
-    dbf : pycalphad.Database
-        Database to consider
-    comps : list
-        List of active component names
-    current_phase : list
-        List of phases to consider
-    phase_models : dict
-        Phase models to pass to pycalphad calculations
-    parameters : dict
-        Dictionary of symbols that will be overridden in pycalphad.equilibrium
-    callables : dict
-        Callables to pass to pycalphad
-    cond_dict : dict
-            Dictionary of state variables, e.g. v.P and v.T, v.X
-    target_hyperplane_chempots : numpy.ndarray
-        Array of chemical potentials for target equilibrium hyperplane.
-    phase_flag : str
-        String of phase flag, e.g. 'disordered'.
-    phase_models : dict
-        Phase models to pass to pycalphad calculations
-    parameters : dict
-        Dictionary of symbols that will be overridden in pycalphad.equilibrium
-
-    Returns
-    -------
-    float
-        Single value for the total error between the current hyperplane and target hyperplane.
-
     """
+    dbf = phase_region.dbf
+    species = phase_region.species
+    phases = phase_region.phases
+    models = phase_region.models
+    current_phase = phase_region.region_phases[vertex_idx]
+    cond_dict = {**phase_region.potential_conds, **phase_region.comp_conds[vertex_idx]}
+    str_statevar_dict = OrderedDict([(str(key),cond_dict[key]) for key in sorted(phase_region.potential_conds.keys(), key=str)])
+    phase_flag = phase_region.phase_flags[vertex_idx]
+    phase_records = phase_region.phase_records[vertex_idx]
+    update_phase_record_parameters(phase_records, parameters)
+    for key, val in cond_dict.items():
+        if val is None:
+            cond_dict[key] = np.nan
     if np.any(np.isnan(list(cond_dict.values()))):
         # We don't actually know the phase composition here, so we estimate it
-        single_eqdata = calculate(dbf, comps, [current_phase],
-                                  T=cond_dict[v.T], P=cond_dict[v.P],
-                                  model=phase_models, parameters=parameters, pdens=100,
-                                  callables=callables, to_xarray=False)
+        single_eqdata = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=500)
         df = np.multiply(target_hyperplane_chempots, single_eqdata.X).sum(axis=-1) - single_eqdata.GM
         driving_force = float(df.max())
     elif phase_flag == 'disordered':
@@ -208,7 +222,7 @@ def driving_force_to_hyperplane(dbf, comps, current_phase, cond_dict, target_hyp
         # Compute energy
         # Compute residual driving force
         # TODO: Check that it actually makes sense to declare this phase 'disordered'
-        num_dof = sum([len(set(c).intersection(comps)) for c in dbf.phases[current_phase].constituents])
+        num_dof = sum([len(set(c).intersection(species)) for c in dbf.phases[current_phase].constituents])
         desired_sitefracs = np.ones(num_dof, dtype=np.float)
         dof_idx = 0
         for c in dbf.phases[current_phase].constituents:
@@ -221,16 +235,13 @@ def driving_force_to_hyperplane(dbf, comps, current_phase, cond_dict, target_hyp
             sitefracs_to_add[np.isnan(sitefracs_to_add)] = 1 - np.nansum(sitefracs_to_add)
             desired_sitefracs[dof_idx:dof_idx + len(dof)] = sitefracs_to_add
             dof_idx += len(dof)
-        single_eqdata = calculate(dbf, comps, [current_phase], T=cond_dict[v.T],
-                                  P=cond_dict[v.P], points=desired_sitefracs,
-                                  model=phase_models, parameters=parameters,
-                                  callables=callables, to_xarray=False,)
+        single_eqdata = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=500)
         driving_force = np.multiply(target_hyperplane_chempots, single_eqdata.X).sum(axis=-1) - single_eqdata.GM
         driving_force = float(np.squeeze(driving_force))
     else:
         # Extract energies from single-phase calculations
-        single_eqdata = equilibrium(dbf, comps, [current_phase], cond_dict, model=phase_models,
-                                    parameters=parameters, callables=callables, to_xarray=False)
+        grid = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=500, fake_points=True)
+        single_eqdata = equilibrium_(species, phase_records, cond_dict, grid)
         if np.all(np.isnan(single_eqdata.NP)):
             logging.debug('Calculation failure: all NaN phases with phases: {}, conditions: {}, parameters {}'.format(current_phase, cond_dict, parameters))
             return np.inf
@@ -244,18 +255,12 @@ def driving_force_to_hyperplane(dbf, comps, current_phase, cond_dict, target_hyp
     return driving_force
 
 
-def calculate_zpf_error(dbf, phases, zpf_data, phase_models=None,
-                        parameters=None, callables=None, data_weight=1.0,
-                        ):
+def calculate_zpf_error(zpf_data: Sequence[Dict[str, Any]],
+                        parameters: np.ndarray = None,
+                        data_weight: int = 1.0):
     """
     Calculate error due to phase equilibria data
 
-    Parameters
-    ----------
-    dbf : pycalphad.Database
-        Database to consider
-    phases : list
-        List of phases to consider
     zpf_data : list
         Datasets that contain single phase data
     phase_models : dict
@@ -286,37 +291,27 @@ def calculate_zpf_error(dbf, phases, zpf_data, phase_models=None,
         parameters = {}
     prob_error = 0.0
     for data in zpf_data:
-        phase_regions = data['phase_regions']
         data_comps = data['data_comps']
         weight = data['weight']
         dataset_ref = data['dataset_reference']
-        # for each set of phases in equilibrium and their individual tieline points
-        for region, region_eq in phase_regions.items():
-            # for each tieline region conditions and compositions
-            for current_statevars, comp_dicts in region_eq:
-                # a "region" is a set of phase equilibria
-                eq_str = "conds: ({}), comps: ({})".format(current_statevars, ', '.join(['{}: {}'.format(ph,c[0]) for ph, c in zip(region, comp_dicts)]))
-                target_hyperplane = estimate_hyperplane(dbf, data_comps, phases, current_statevars, comp_dicts, phase_models, parameters, callables=callables)
-                if np.any(np.isnan(target_hyperplane)):
-                    zero_probs = norm(loc=0, scale=1000/data_weight/weight).logpdf(np.zeros(len(region)))
-                    total_zero_prob = np.sum(zero_probs)
-                    logging.debug('ZPF error - NaN target hyperplane. Equilibria: ({}), reference: {}. Treating all driving force: 0.0, probability: {}, probabilities: {}'.format(eq_str, dataset_ref, total_zero_prob, zero_probs))
-                    prob_error += total_zero_prob
-                    continue
-                # Now perform the equilibrium calculation for the isolated phases and add the result to the error record
-                for current_phase, cond_dict in zip(region, comp_dicts):
-                    # TODO: Messy unpacking
-                    cond_dict, phase_flag = cond_dict
-                    # We are now considering a particular tie vertex
-                    for key, val in cond_dict.items():
-                        if val is None:
-                            cond_dict[key] = np.nan
-                    cond_dict.update(current_statevars)
-                    driving_force = driving_force_to_hyperplane(dbf, data_comps, current_phase, cond_dict, target_hyperplane,
-                                                  phase_flag, phase_models, parameters, callables=callables)
-                    vertex_prob = norm(loc=0, scale=1000/data_weight/weight).logpdf(driving_force)
-                    prob_error += vertex_prob
-                    logging.debug('ZPF error - Equilibria: ({}), current phase: {}, driving force: {}, probability: {}, reference: {}'.format(eq_str, current_phase, driving_force, vertex_prob, dataset_ref))
+        # for the set of phases and corresponding tie-line verticies in equilibrium
+        for phase_region in data['phase_regions']:
+            # Calculate the average multiphase hyperplane
+            eq_str = "conds: ({}), comps: ({})".format(phase_region.potential_conds, ', '.join(['{}: {}'.format(ph, c) for ph, c in zip(phase_region.region_phases, phase_region.comp_conds)]))
+            target_hyperplane = estimate_hyperplane(phase_region, parameters)
+            if np.any(np.isnan(target_hyperplane)):
+                zero_probs = norm(loc=0, scale=1000/data_weight/weight).logpdf(np.zeros(len(region)))
+                total_zero_prob = np.sum(zero_probs)
+                logging.debug('ZPF error - NaN target hyperplane. Equilibria: ({}), reference: {}. Treating all driving force: 0.0, probability: {}, probabilities: {}'.format(eq_str, dataset_ref, total_zero_prob, zero_probs))
+                prob_error += total_zero_prob
+                continue
+            # Then calculate the driving force to that hyperplane for each individual vertex
+            #     # region_phases, comp_conds, phase_flags, phase_records
+            for vertex_idx in range(len(phase_region.comp_conds)):
+                driving_force = driving_force_to_hyperplane(target_hyperplane, data_comps, phase_region, vertex_idx, parameters)
+                vertex_prob = norm(loc=0, scale=1000/data_weight/weight).logpdf(driving_force)
+                prob_error += vertex_prob
+                logging.debug('ZPF error - Equilibria: ({}), current phase: {}, driving force: {}, probability: {}, reference: {}'.format(eq_str, phase_region.region_phases[vertex_idx], driving_force, vertex_prob, dataset_ref))
     if np.isnan(prob_error):
         return -np.inf
     return prob_error

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -36,8 +36,9 @@ def _safe_index(items, index):
         return None
 
 def update_phase_record_parameters(phase_records: Dict[str, PhaseRecord], parameters: np.ndarray) -> None:
-    for phase_name, phase_record in phase_records.items():
-        phase_record.parameters[:] = parameters
+    if parameters.size > 0:
+        for phase_name, phase_record in phase_records.items():
+            phase_record.parameters[:] = parameters
 
 def extract_conditions(all_conditions: Dict[v.StateVariable, np.ndarray], idx: int) -> Dict[v.StateVariable, float]:
     """Conditions are either scalar or 1d arrays for the conditions in the entire dataset.
@@ -288,7 +289,7 @@ def calculate_zpf_error(zpf_data: Sequence[Dict[str, Any]],
 
     """
     if parameters is None:
-        parameters = {}
+        parameters = np.array([])
     prob_error = 0.0
     for data in zpf_data:
         data_comps = data['data_comps']

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -79,7 +79,7 @@ def extract_phases_comps(phase_region):
 
 PhaseRegion = NamedTuple('PhaseRegion', (('region_phases', Sequence[str]),
                                          ('potential_conds', Dict[v.StateVariable, float]),
-                                         ('comp_conds', Sequence[Dict[v.Composition, float]]),
+                                         ('comp_conds', Sequence[Dict[v.X, float]]),
                                          ('phase_flags', Sequence[str]),
                                          ('dbf', Database),
                                          ('species', Sequence[v.Species]),

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -245,6 +245,7 @@ def run_espei(run_settings):
         prior = mcmc_settings.get('prior')
         data_weights = mcmc_settings.get('data_weights')
         syms = mcmc_settings.get('symbols')
+        approximate_equilibrium = mcmc_settings.get('approximate_equilibrium')
 
         # set up and run the EmceeOptimizer
         optimizer = EmceeOptimizer(dbf, scheduler=client)
@@ -255,7 +256,9 @@ def run_espei(run_settings):
                       chain_std_deviation=chain_std_deviation,
                       deterministic=deterministic, restart_trace=restart_trace,
                       tracefile=tracefile, probfile=probfile,
-                      mcmc_data_weights=data_weights)
+                      mcmc_data_weights=data_weights,
+                      approximate_equilibrium=approximate_equilibrium,
+                      )
         optimizer.commit()
 
         optimizer.dbf.to_file(output_settings['output_db'], if_exists='overwrite')

--- a/espei/input-schema.yaml
+++ b/espei/input-schema.yaml
@@ -118,6 +118,10 @@ mcmc:
       type: boolean
       default: True
       required: True
+    approximate_equilibrium:  # Whether to use an approximate (not refined) equilibrium based on `starting_point`
+      type: boolean
+      default: False
+      required: True
     data_weights:
       type: dict
       default: {'ZPF': 1.0, 'ACR': 1.0, 'HM': 1.0, 'SM': 1.0, 'CPM': 1.0}

--- a/espei/optimizers/opt_mcmc.py
+++ b/espei/optimizers/opt_mcmc.py
@@ -266,7 +266,7 @@ class EmceeOptimizer(OptimizerBase):
         starttime = time.time()
         if zpf_kwargs is not None:
             try:
-                multi_phase_error = calculate_zpf_error(parameters=parameters, **zpf_kwargs)
+                multi_phase_error = calculate_zpf_error(parameters=np.array(params), **zpf_kwargs)
             except (ValueError, np.linalg.LinAlgError) as e:
                 raise e
                 print(e)

--- a/espei/optimizers/opt_mcmc.py
+++ b/espei/optimizers/opt_mcmc.py
@@ -167,7 +167,7 @@ class EmceeOptimizer(OptimizerBase):
     def _fit(self, symbols, ds, prior=None, iterations=1000,
              chains_per_parameter=2, chain_std_deviation=0.1, deterministic=True,
              restart_trace=None, tracefile=None, probfile=None,
-             mcmc_data_weights=None,
+             mcmc_data_weights=None, approximate_equilibrium=False,
              ):
         """
 
@@ -214,6 +214,7 @@ class EmceeOptimizer(OptimizerBase):
 
         prior_dict = self.get_priors(prior, symbols_to_fit, initial_guess)
         ctx.update(prior_dict)
+        ctx['zpf_kwargs']['approximate_equilibrium'] = approximate_equilibrium
         # Run the initial parameters for guessing purposes:
         logging.log(TRACE, "Probability for initial parameters")
         self.predict(initial_guess, **ctx)

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -157,7 +157,7 @@ def dataplot(comps, phases, conds, datasets, ax=None, plot_kwargs=None, tieline_
     >>> dataplot(my_components, my_phases, conditions, datasets)  # doctest: +SKIP
 
     """
-    indep_comps = [key for key, value in conds.items() if isinstance(key, v.Composition) and len(np.atleast_1d(value)) > 1]
+    indep_comps = [key for key, value in conds.items() if isinstance(key, v.X) and len(np.atleast_1d(value)) > 1]
     indep_pots = [key for key, value in conds.items() if ((key == v.T) or (key == v.P)) and len(np.atleast_1d(value)) > 1]
     plot_kwargs = plot_kwargs or {}
     phases = sorted(phases)

--- a/espei/shadow_functions.py
+++ b/espei/shadow_functions.py
@@ -28,7 +28,7 @@ def calculate_(dbf: Database, species: Sequence[v.Species], phases: Sequence[str
     points_dict = unpack_kwarg(points, default_arg=None)
     pdens_dict = unpack_kwarg(pdens, default_arg=2000)
     nonvacant_components = [x for x in sorted(species) if x.number_of_atoms > 0]
-    maximum_internal_dof = max(len(models[phase_name].site_fractions) for phase_name in phases)
+    maximum_internal_dof = max(prx.phase_dof for prx in phase_records.values())
     all_phase_data = []
     for phase_name in sorted(phases):
         phase_obj = dbf.phases[phase_name]

--- a/espei/shadow_functions.py
+++ b/espei/shadow_functions.py
@@ -1,0 +1,100 @@
+"""
+Fast versions of equilibrium and calculate that "override" the equivalent
+pycalphad functions for very fast performance.
+"""
+
+from collections import OrderedDict
+from typing import Sequence, Dict, Optional
+import numpy as np
+from pycalphad import Database, Model, variables as v
+from pycalphad.core.phase_rec import PhaseRecord
+from pycalphad.core.starting_point import starting_point
+from pycalphad.core.eqsolver import _solve_eq_at_conditions
+from pycalphad.core.equilibrium import _adjust_conditions
+from pycalphad.core.utils import get_state_variables, unpack_kwarg, point_sample, generate_dof
+from pycalphad.core.light_dataset import LightDataset
+from pycalphad.core.calculate import _sample_phase_constitution, _compute_phase_values
+
+def calculate_(dbf: Database, species: Sequence[v.Species], phases: Sequence[str],
+               str_statevar_dict: Dict[str, np.ndarray], models: Dict[str, Model],
+               phase_records: Dict[str, PhaseRecord], output: Optional[str] = 'GM',
+               points: Optional[Dict[str, np.ndarray]] = None,
+               pdens: Optional[int] = 2000, broadcast: Optional[bool] = True,
+               fake_points: Optional[bool] = False,
+               ) -> LightDataset:
+    """
+    Quickly sample phase internal degree of freedom with virtually no overhead.
+    """
+    points_dict = unpack_kwarg(points, default_arg=None)
+    pdens_dict = unpack_kwarg(pdens, default_arg=2000)
+    nonvacant_components = [x for x in sorted(species) if x.number_of_atoms > 0]
+    maximum_internal_dof = max(len(models[phase_name].site_fractions) for phase_name in phases)
+    all_phase_data = []
+    for phase_name in sorted(phases):
+        phase_obj = dbf.phases[phase_name]
+        mod = models[phase_name]
+        phase_record = phase_records[phase_name]
+        points = points_dict[phase_name]
+        variables, sublattice_dof = generate_dof(phase_obj, mod.components)
+        if points is None:
+            points = _sample_phase_constitution(phase_name, phase_obj.constituents, sublattice_dof, species,
+                                                tuple(variables), point_sample, True, pdens_dict[phase_name])
+        points = np.atleast_2d(points)
+
+        fp = fake_points and (phase_name == sorted(phases)[0])
+        phase_ds = _compute_phase_values(nonvacant_components, str_statevar_dict,
+                                         points, phase_record, output,
+                                         maximum_internal_dof, broadcast=broadcast,
+                                         largest_energy=float(1e10), fake_points=fp)
+        all_phase_data.append(phase_ds)
+
+    if len(all_phase_data) > 1:
+        concatenated_coords = all_phase_data[0].coords
+
+        data_vars = all_phase_data[0].data_vars
+        concatenated_data_vars = {}
+        for var in data_vars.keys():
+            data_coords = data_vars[var][0]
+            points_idx = data_coords.index('points')  # concatenation axis
+            arrs = []
+            for phase_data in all_phase_data:
+                arrs.append(getattr(phase_data, var))
+            concat_data = np.concatenate(arrs, axis=points_idx)
+            concatenated_data_vars[var] = (data_coords, concat_data)
+        final_ds = LightDataset(data_vars=concatenated_data_vars, coords=concatenated_coords)
+    else:
+        final_ds = all_phase_data[0]
+    return final_ds
+
+
+def equilibrium_(species: Sequence[v.Species], phase_records: Dict[str, PhaseRecord],
+                 conditions: Dict[v.StateVariable, np.ndarray], grid: LightDataset
+                 ) -> LightDataset:
+    """
+    Perform a fast equilibrium calculation with virtually no overhead.
+    """
+    statevars = get_state_variables(conds=conditions)
+    conditions = _adjust_conditions(conditions)
+    str_conds = OrderedDict([(str(ky), conditions[ky]) for ky in sorted(conditions.keys(), key=str)])
+    start_point = starting_point(conditions, statevars, phase_records, grid)
+    return _solve_eq_at_conditions(species, start_point, phase_records, grid, str_conds, statevars, False)
+
+
+def no_op_equilibrium_(_, phase_records: Dict[str, PhaseRecord],
+                       conditions: Dict[v.StateVariable, np.ndarray],
+                       grid: LightDataset,
+                       ) -> LightDataset:
+    """
+    Perform a fast "equilibrium" calculation with virtually no overhead that
+    doesn't refine the solution or do global minimization, but just returns
+    the starting point.
+
+    Notes
+    -----
+    Uses a placeholder first argument for the same signature as
+    ``_equilibrium``, but ``species`` are not needed.
+
+    """
+    statevars = get_state_variables(conds=conditions)
+    conditions = _adjust_conditions(conditions)
+    return starting_point(conditions, statevars, phase_records, grid)

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -175,6 +175,6 @@ def test_zpf_error_zero(datasets_db):
     # ZPF weight = 1 kJ and there are two points in the tieline
     zero_error_prob = 2 * scipy.stats.norm(loc=0, scale=1000.0).logpdf(0.0)
 
-    zpf_data = get_zpf_data(comps, phases, datasets_db)
-    error = calculate_zpf_error(dbf, phases, zpf_data)
+    zpf_data = get_zpf_data(dbf, comps, phases, datasets_db, {})
+    error = calculate_zpf_error(zpf_data, np.array([]))
     assert np.isclose(error, zero_error_prob, rtol=1e-6)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -146,6 +146,7 @@ def test_correct_defaults_are_applied_from_minimal_specification():
     assert d['mcmc'].pop('chains_per_parameter') == 2
     assert d['mcmc'].pop('chain_std_deviation') == 0.1
     assert d['mcmc'].pop('deterministic') == True
+    assert d['mcmc'].pop('approximate_equilibrium') == False
     assert d['mcmc'].pop('data_weights') == {'ACR': 1.0, 'CPM': 1.0, 'HM': 1.0, 'SM': 1.0, 'ZPF': 1.0}
     assert d['mcmc'].pop('prior') == {'name': 'zero'}
     assert len(d['mcmc']) == 1


### PR DESCRIPTION
Calculating the driving force error for phase boundary data is typically the most computationally intensive part of running ESPEI.

** Requires https://github.com/pycalphad/pycalphad/pull/264 to run these commits in parallel!**

This PR tries to optimize (and simplify) calculating the ZPF error by doing the following:

1. Introduces a `PhaseRegion` NamedTuple that describes the data to calculate for each phase boundary set, instead of passing around all the data lists disparately. 
    * This significantly reduces the complexity of the driving force calculation. 
    * The `PhaseRegion` gets its own PhaseRecords for the calculation and contains all the relevant equilibrium arguments for that specific data. This therefore fixes a bug for mixing data types across different systems, e.g. fitting a ternary database with binary data, which used to fail because the callables/PhaseRecords would be built for the ternary, but there were only composition information for the binary and the PhaseRecords were not re-computed each time. For this reason, https://github.com/pycalphad/pycalphad/pull/264 is required to run ESPEI in parallel, since SymEngine Lambda compiled objects cannot be pickled.
    * PhaseRecords are now updated for each parameter set that is calculated. This is an optimization that prevents recalculating the constraints and recompiling the constraints every time equilibrium is called, since each tieline point in the PhaseRegion will always have the same conditions and therefore constraints.
2. "Shadow functions" are implemented that shadow pycalphad's `calculate` (`calculate_`) and `equilibrium` (`equilibrium_`). These are optimized versions of pycalphad's functions that operate directly on the species, phase records, and other pycalphad internal objects as much as possible to optimize calls.
3. A `no_op_equilibrium_` "shadow function" (it doesn't really shadow anything, but exists in the same vein) which doesn't actually call `solve_eq_at_conditions` and instead just treats the `starting_point` solution as the equilibrium solution. This can give large speedups (I have already seen 3x-10x for ZPF data in certain tests systems)
4. An `approximate_equilibrium` setting in the ESPEI yaml files, which defaults to False. 

Closes #99 