### PR TITLE
FIX: Add explicit support and tests for subsystems

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -112,6 +112,7 @@ These are created from arrays via ``numpy.save()`` and can thus be loaded with `
 Note that the arrays are preallocated with zeros.
 These filenames and settings can be changed using in the input file.
 You can then use these chains and corresponding log-probabilities to make corner plots, calculate autocorrelations, find optimal parameters for databases, etc..
+Some examples are shown in the :ref:`Recipes` page.
 Finally, you can use py:mod:`espei.plot` functions such as ``multiplot`` to plot phase diagrams with your input equilibria data and ``plot_parameters`` to compare single-phase data (e.g. formation and mixing data) with the properties calculated with your database.
 
 Q: Can I run ESPEI on a supercomputer supporting MPI?
@@ -133,7 +134,6 @@ The total log probability is the sum of all log probabilities.
 
 Note that any probability density function always returns a positive value between 0 and 1, so the log probability density function should return negative numbers and the log probability reported by ESPEI should be negative.
 
-:ref:`Writing input files`
 
 Q: Why is the version of ESPEI '0+unknown'?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,6 +141,20 @@ Q: Why is the version of ESPEI '0+unknown'?
 A: A version number of ``'0+unknown'`` indicates that you do not have git installed.
 This can occur on Windows where git is not in the PATH (and the Python interpreter cannot see it).
 You can install git using ``conda install git`` on Windows.
+
+
+Q: I have a large database, can I use ESPEI to optimize parameters in only a subsystem?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A: Yes, if you have a multicomponent CALPHAD database, but want to optimize or
+determine the uncertainty for a constituent unary, binary or ternary subsystem
+that you have data for, you can do that without any extra effort.
+
+You may be interested in the :ref:`input_mcmc_symbols` input parameter to
+specify which parameter subset to optimize.
+
+Note that if you optimize parameters in a subsystem (e.g. Cu-Mg) that is used in a higher order description (e.g. Al-Cu-Mg), you may need to reoptimize the parameters for the higher order system as well.
+
 
 References
 ==========

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -2,6 +2,8 @@
 
    \chapter{Recipes}
 
+.. _Recipes:
+
 =======
 Recipes
 =======

--- a/docs/writing_input.rst
+++ b/docs/writing_input.rst
@@ -453,6 +453,8 @@ used to modify the initial standard deviation of each data type by
     :alt: Data weight equation
     :scale: 100%
 
+.. _input_mcmc_symbols:
+
 symbols
 -------
 

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -9,6 +9,7 @@ import tinydb
 
 from pycalphad import equilibrium, variables as v
 from pycalphad.plot.eqplot import _map_coord_to_variable
+from pycalphad.core.utils import filter_phases
 from scipy.stats import norm
 
 from espei.core_utils import ravel_conditions
@@ -121,8 +122,13 @@ def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phas
         acr_component = ds['output'].split('_')[1]  # the component of interest
         # calculate the reference state equilibrium
         ref = ds['reference_state']
+        # data_comps and data_phases ensures that we only do calculations on
+        # the subsystem of the system defining the data.
+        data_comps = ds['components']
+        species = list(map(v.Species, data_comps))
+        data_phases = filter_phases(dbf, species, candidate_phases=phases)
         ref_conditions = {_map_coord_to_variable(coord): val for coord, val in ref['conditions'].items()}
-        ref_result = equilibrium(dbf, ds['components'], ref['phases'], ref_conditions,
+        ref_result = equilibrium(dbf, data_comps, ref['phases'], ref_conditions,
                                  model=phase_models, parameters=parameters,
                                  callables=callables)
 
@@ -146,7 +152,7 @@ def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phas
         conditions_list = [{c: conditions[c][i] for c in conditions.keys()} for i in range(len(conditions[v.T]))]
         current_chempots = []
         for conds in conditions_list:
-            sample_eq_res = equilibrium(dbf, ds['components'], phases, conds,
+            sample_eq_res = equilibrium(dbf, data_comps, data_phases, conds,
                                         model=phase_models, parameters=parameters,
                                         callables=callables)
             current_chempots.append(sample_eq_res.MU.sel(component=acr_component).values.flatten()[0])

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -24,7 +24,7 @@ import tinydb
 
 from pycalphad import Database, Model, variables as v
 from pycalphad.codegen.callables import build_phase_records
-from pycalphad.core.utils import instantiate_models
+from pycalphad.core.utils import instantiate_models, filter_phases
 from pycalphad.core.phase_rec import PhaseRecord
 from espei.utils import PickleableTinyDB
 from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_
@@ -119,7 +119,8 @@ def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], dat
     for data in desired_data:
         data_comps = list(set(data['components']).union({'VA'}))
         species = sorted(map(v.Species, data_comps), key=str)
-        models = instantiate_models(dbf, species, phases, parameters=parameters)
+        data_phases = filter_phases(dbf, species, candidate_phases=phases)
+        models = instantiate_models(dbf, species, data_phases, parameters=parameters)
         all_regions = data['values']
         conditions = data['conditions']
         phase_regions = []
@@ -135,9 +136,9 @@ def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], dat
             region_potential_conds[v.N] = region_potential_conds.get(v.N) or 1.0  # Add v.N condition, if missing
             # Extract all the phases and compositions from the tie-line points
             region_phases, region_comp_conds, phase_flags = extract_phases_comps(phase_region)
-            region_phase_records = [build_phase_records(dbf, species, phases, {**region_potential_conds, **comp_conds}, models, parameters=parameters, build_gradients=True, build_hessians=True)
+            region_phase_records = [build_phase_records(dbf, species, data_phases, {**region_potential_conds, **comp_conds}, models, parameters=parameters, build_gradients=True, build_hessians=True)
                                     for comp_conds in region_comp_conds]
-            phase_regions.append(PhaseRegion(region_phases, region_potential_conds, region_comp_conds, phase_flags, dbf, species, phases, models, region_phase_records))
+            phase_regions.append(PhaseRegion(region_phases, region_potential_conds, region_comp_conds, phase_flags, dbf, species, data_phases, models, region_phase_records))
 
         data_dict = {
             'weight': data.get('weight', 1.0),

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -185,6 +185,30 @@ def test_non_equilibrium_thermochemical_error_for_of_enthalpy_mixing(datasets_db
     assert np.isclose(error, zero_error_prob, atol=1e-6)
 
 
+def test_subsystem_non_equilibrium_thermochemcial_probability(datasets_db):
+    """Test binary Cr-Ni data produces the same probability regardless of whether the main system is a binary or ternary."""
+
+    datasets_db.insert(CR_NI_LIQUID_DATA)
+
+    dbf_bin = Database(CR_NI_TDB)
+    dbf_tern = Database(CR_FE_NI_TDB)
+    phases = list(dbf_bin.phases.keys())
+
+    # Truth
+    thermochemical_data = get_thermochemical_data(dbf_bin, ['CR', 'NI', 'VA'], phases, datasets_db)
+    bin_prob = calculate_non_equilibrium_thermochemical_probability(dbf_bin, thermochemical_data)
+
+    # Getting binary subsystem data explictly (from binary input)
+    thermochemical_data = get_thermochemical_data(dbf_tern, ['CR', 'NI', 'VA'], phases, datasets_db)
+    prob = calculate_non_equilibrium_thermochemical_probability(dbf_tern, thermochemical_data)
+    assert np.isclose(prob, bin_prob)
+
+    # Getting binary subsystem from ternary input
+    thermochemical_data = get_thermochemical_data(dbf_tern, ['CR', 'FE', 'NI', 'VA'], phases, datasets_db)
+    prob = calculate_non_equilibrium_thermochemical_probability(dbf_tern, thermochemical_data)
+    assert np.isclose(prob, bin_prob)
+
+
 def test_zpf_error_zero(datasets_db):
     """Test that sum of square ZPF errors returns 0 for an exactly correct result"""
     datasets_db.insert(CU_MG_DATASET_ZPF_ZERO_ERROR)
@@ -199,3 +223,27 @@ def test_zpf_error_zero(datasets_db):
     zpf_data = get_zpf_data(dbf, comps, phases, datasets_db, {})
     error = calculate_zpf_error(zpf_data, np.array([]))
     assert np.isclose(error, zero_error_prob, rtol=1e-6)
+
+
+def test_subsystem_zpf_probability(datasets_db):
+    """Test binary Cr-Ni data produces the same probability regardless of whether the main system is a binary or ternary."""
+
+    datasets_db.insert(CR_NI_ZPF_DATA)
+
+    dbf_bin = Database(CR_NI_TDB)
+    dbf_tern = Database(CR_FE_NI_TDB)
+    phases = list(dbf_bin.phases.keys())
+
+    # Truth
+    zpf_data = get_zpf_data(dbf_bin, ['CR', 'NI', 'VA'], phases, datasets_db, {})
+    bin_prob = calculate_zpf_error(zpf_data, np.array([]))
+
+    # Getting binary subsystem data explictly (from binary input)
+    zpf_data = get_zpf_data(dbf_tern, ['CR', 'NI', 'VA'], phases, datasets_db, {})
+    prob = calculate_zpf_error(zpf_data, np.array([]))
+    assert np.isclose(prob, bin_prob)
+
+    # Getting binary subsystem from ternary input
+    zpf_data = get_zpf_data(dbf_tern, ['CR', 'FE', 'NI', 'VA'], phases, datasets_db, {})
+    prob = calculate_zpf_error(zpf_data, np.array([]))
+    assert np.isclose(prob, bin_prob)

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -25,6 +25,27 @@ def test_activity_error(datasets_db):
     assert np.isclose(error, -257.41020886970756, rtol=1e-6)
 
 
+def test_subsystem_activity_probability(datasets_db):
+    """Test binary Cr-Ni data produces the same probability regardless of whether the main system is a binary or ternary."""
+
+    datasets_db.insert(CR_NI_ACTIVITY)
+
+    dbf_bin = Database(CR_NI_TDB)
+    dbf_tern = Database(CR_FE_NI_TDB)
+    phases = list(dbf_bin.phases.keys())
+
+    # Truth
+    bin_prob = calculate_activity_error(dbf_bin, ['CR','NI','VA'], phases, datasets_db, {}, {}, {})
+
+    # Getting binary subsystem data explictly (from binary input)
+    prob = calculate_activity_error(dbf_tern, ['CR','NI','VA'], phases, datasets_db, {}, {}, {})
+    assert np.isclose(prob, bin_prob)
+
+    # Getting binary subsystem from ternary input
+    prob = calculate_activity_error(dbf_tern, ['CR', 'FE', 'NI','VA'], phases, datasets_db, {}, {}, {})
+    assert np.isclose(prob, bin_prob)
+
+
 def test_non_equilibrium_thermochemical_error_with_multiple_X_points(datasets_db):
     """Multiple composition datapoints in a dataset for a mixing phase should be successful."""
     datasets_db.insert(CU_MG_CPM_MIX_X_HCP_A3)

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -32,7 +32,7 @@ def test_subsystem_activity_probability(datasets_db):
 
     dbf_bin = Database(CR_NI_TDB)
     dbf_tern = Database(CR_FE_NI_TDB)
-    phases = list(dbf_bin.phases.keys())
+    phases = list(dbf_tern.phases.keys())
 
     # Truth
     bin_prob = calculate_activity_error(dbf_bin, ['CR','NI','VA'], phases, datasets_db, {}, {}, {})
@@ -42,7 +42,7 @@ def test_subsystem_activity_probability(datasets_db):
     assert np.isclose(prob, bin_prob)
 
     # Getting binary subsystem from ternary input
-    prob = calculate_activity_error(dbf_tern, ['CR', 'FE', 'NI','VA'], phases, datasets_db, {}, {}, {})
+    prob = calculate_activity_error(dbf_tern, ['CR', 'FE', 'NI', 'VA'], phases, datasets_db, {}, {}, {})
     assert np.isclose(prob, bin_prob)
 
 
@@ -192,7 +192,7 @@ def test_subsystem_non_equilibrium_thermochemcial_probability(datasets_db):
 
     dbf_bin = Database(CR_NI_TDB)
     dbf_tern = Database(CR_FE_NI_TDB)
-    phases = list(dbf_bin.phases.keys())
+    phases = list(dbf_tern.phases.keys())
 
     # Truth
     thermochemical_data = get_thermochemical_data(dbf_bin, ['CR', 'NI', 'VA'], phases, datasets_db)
@@ -232,7 +232,7 @@ def test_subsystem_zpf_probability(datasets_db):
 
     dbf_bin = Database(CR_NI_TDB)
     dbf_tern = Database(CR_FE_NI_TDB)
-    phases = list(dbf_bin.phases.keys())
+    phases = list(dbf_tern.phases.keys())
 
     # Truth
     zpf_data = get_zpf_data(dbf_bin, ['CR', 'NI', 'VA'], phases, datasets_db, {})

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -624,7 +624,7 @@ CR_NI_LIQUID_DATA = {
 
 CR_NI_ZPF_DATA = {
     "components": ["CR", "NI", "VA"],
-    "phases": ["A2", "A1"],
+    "phases": ["BCC_A2", "FCC_A1"],
     "broadcast_conditions": False,
     "conditions": {
         "T": [1073, 1173, 1273, 1373, 1548],
@@ -632,11 +632,11 @@ CR_NI_ZPF_DATA = {
     },
     "output": "ZPF",
     "values": [
-        [["A1", ["CR"], [0.3866]], ["A2", ["NI"], [None]]],
-        [["A1", ["CR"], [0.3975]], ["A2", ["NI"], [None]]],
-        [["A1", ["CR"], [0.4480]], ["A2", ["NI"], [None]]],
-        [["A1", ["CR"], [0.4643]], ["A2", ["NI"], [None]]],
-        [["A1", ["CR"], [0.4984]], ["A2", ["NI"], [None]]]
+        [["FCC_A1", ["CR"], [0.3866]], ["BCC_A2", ["NI"], [None]]],
+        [["FCC_A1", ["CR"], [0.3975]], ["BCC_A2", ["NI"], [None]]],
+        [["FCC_A1", ["CR"], [0.4480]], ["BCC_A2", ["NI"], [None]]],
+        [["FCC_A1", ["CR"], [0.4643]], ["BCC_A2", ["NI"], [None]]],
+        [["FCC_A1", ["CR"], [0.4984]], ["BCC_A2", ["NI"], [None]]]
     ],
     "reference": "zpf test", "comment": ""
 }
@@ -783,6 +783,12 @@ Constituent FCC_A1 : CR,FE,NI : VA : !
  PARAMETER G(FCC_A1,CR,FE,NI:VA;1) 300 -6500;               6000 N !
  PARAMETER G(FCC_A1,CR,FE,NI:VA;2) 300 +48000;              6000 N !
 
+$ Designed to only stabilize in the ternary Cr-Fe-Ni
+Phase FEONLY % 2  1  1  !
+Constituent FEONLY : FE : VA : !
+
+ PARAMETER G(FEONLY,FE:VA;0) 300  -100000000; 6000 N !
+
 
 """
 
@@ -859,7 +865,6 @@ Constituent FCC_A1 : CR,NI : VA : !
 
  PARAMETER G(FCC_A1,CR,NI:VA;0)  300 +8030-12.8801*T;       6000 N !
  PARAMETER G(FCC_A1,CR,NI:VA;1)  300 +33080-16.0362*T;      6000 N !
-
 
 """
 

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -604,3 +604,262 @@ $             *******   BCC_A2   ************
    PARAMETER TC(BCC_A2,CR,FE:VA;0)  2.98150E+02   865.5; 6000 N !
    PARAMETER TC(BCC_A2,CR,FE:VA;1)  2.98150E+02   -567.2; 6000 N !
 """
+
+
+CR_NI_LIQUID_DATA = {
+    "components": ["CR", "NI"],
+    "phases": ["LIQUID"],
+    "solver": {
+        "mode": "manual",
+        "sublattice_site_ratios": [1],
+        "sublattice_configurations": [[["CR", "NI"]], [["CR", "NI"]], [["CR", "NI"]], [["CR", "NI"]]],
+        "sublattice_occupancies": [[[0.023, 0.977]], [[0.048, 0.952]], [[0.075, 0.925]], [[0.073, 0.927]]]
+    },
+    "conditions": {"P": 101325, "T": 1729},
+    "output": "HM_MIX",
+    "values": [[[-300, -700, -1200, -1200]]],
+    "reference": "non-equilibrium thermochemical tests", "comment": ""
+}
+
+
+CR_NI_ZPF_DATA = {
+    "components": ["CR", "NI", "VA"],
+    "phases": ["A2", "A1"],
+    "broadcast_conditions": False,
+    "conditions": {
+        "T": [1073, 1173, 1273, 1373, 1548],
+        "P": [101325.0]
+    },
+    "output": "ZPF",
+    "values": [
+        [["A1", ["CR"], [0.3866]], ["A2", ["NI"], [None]]],
+        [["A1", ["CR"], [0.3975]], ["A2", ["NI"], [None]]],
+        [["A1", ["CR"], [0.4480]], ["A2", ["NI"], [None]]],
+        [["A1", ["CR"], [0.4643]], ["A2", ["NI"], [None]]],
+        [["A1", ["CR"], [0.4984]], ["A2", ["NI"], [None]]]
+    ],
+    "reference": "zpf test", "comment": ""
+}
+
+
+CR_NI_ACTIVITY = {
+    "components": ["CR", "NI", "VA"],
+    "phases": ["LIQUID"],
+    "reference_state": {
+        "phases": ["LIQUID"],
+        "conditions": {"P": 101325, "T": 1200, "X_NI": 1.0}
+    },
+    "conditions": {"P": 101325, "T": 1200, "X_NI": [0.9]},
+    "output": "ACR_NI",
+    "values": [[[0.9]]],
+    "reference": "activity test", "comment": "Example, nearly ideal"
+}
+
+CR_FE_NI_TDB = """
+Element VA                VACUUM         0         0         0  !
+ELEMENT CR                BCC_A2    51.996      4050    23.560  !
+ELEMENT FE                BCC_A2    55.847      4489    27.28   !
+Element NI                FCC_A1    58.69       4787    29.7955 !
+
+FUNCTION GLIQCR  300 +15483.015+146.059775*T-26.908*T*LN(T)
+   +.00189435*T**2-1.47721E-06*T**3+139250*T**(-1)+2.37615E-21*T**7;  2180 Y
+   -16459.984+335.616316*T-50*T*LN(T);                                6000 N !
+FUNCTION GBCCCR  300 -8856.94+157.48*T
+ -26.908*T*LN(T)+.00189435*T**2-1.47721E-06*T**3+139250*T**(-1);      2180 Y
+  -34869.344+344.18*T-50*T*LN(T)-2.885261E+32*T**(-9);                6000 N !
+FUNCTION GFCCCR  300 -1572.94+157.643*T
+ -26.908*T*LN(T)+.00189435*T**2-1.47721E-06*T**3+139250*T**(-1);      2180 Y
+  -27585.344+344.343*T-50*T*LN(T)-2.885261E+32*T**(-9);               6000 N !
+FUNCTION GBCCFE  300  +1225.7+124.134*T-23.5143*T*LN(T)
+     -.00439752*T**2-5.8927E-08*T**3+77359*T**(-1);                    1811 Y
+      -25383.581+299.31255*T-46*T*LN(T)+2.29603E+31*T**(-9);           6000 N !
+FUNCTION GFCCFE 300 -1462.4+8.282*T-1.15*T*LN(T)+6.4E-4*T**2+GBCCFE;   1811 Y
+      -1713.815+0.94001*T+4.9251E+30*T**(-9)+GBCCFE;                   6000 N !
+FUNCTION GLIQFE  300  +13265.87+117.57557*T-23.5143*T*LN(T)
+      -0.00439752*T**2-5.8927E-08*T**3+77359*T**(-1)-3.67516E-21*T**7; 1811 Y
+      -10838.83+291.302*T-46*T*LN(T);                                  6000 N !
+FUNCTION GFCCNI  300 -5179.159+117.854*T
+      -22.096*T*ln(T)-0.0048407*T**2;                                 1728 Y
+      -27840.655+279.135*T-43.1*T*ln(T)+1.12754e+031*T**(-9);         3000 N !
+FUNCTION GLIQNI  300  11235.527+108.457*T-22.096*T*ln(T)
+      -0.0048407*T**2-3.82318e-021*T**7;                              1728 Y
+      -9549.775+268.598*T-43.1*T*ln(T);                               3000 N !
+FUNCTION GBCCNI     300  +8715.084-3.556*T+GFCCNI;                    6000 N !
+
+FUNCTION ZERO       300  +0;                                          6000 N !
+FUNCTION UN_ASS     300  +0;                                          6000 N !
+
+
+TYPE_DEFINITION % SEQ * !
+DEFINE_SYSTEM_DEFAULT ELEMENT 3 !
+
+TYPE_DEFINITION ' GES A_P_D BCC_A2 MAGNETIC  -1    0.4  !
+Type_Definition ( GES A_P_D FCC_A1 Magnetic  -3    0.28 !
+
+ Phase LIQUID % 1 1 !
+ Constituent LIQUID : CR,FE,NI : !
+
+ PARAMETER G(LIQUID,CR;0)     300  +GLIQCR;               6000 N !
+ PARAMETER G(LIQUID,FE;0)     300  +GLIQFE;               6000 N !
+ PARAMETER G(LIQUID,NI;0)     300  +GLIQNI;               6000 N !
+
+ PARAMETER G(LIQUID,CR,FE;0)  300  -17737+7.996546*T;     6000 N !
+ PARAMETER G(LIQUID,CR,FE;1)  300  -1331;                 6000 N !
+ PARAMETER G(LIQUID,CR,NI;0)  300  +318-7.3318*T;         6000 N !
+ PARAMETER G(LIQUID,CR,NI;1)  300  +16941-6.3696*T;       6000 N !
+ PARAMETER G(LIQUID,FE,NI;0)  300  -16911+5.1622*T;       6000 N !
+ PARAMETER G(LIQUID,FE,NI;1)  300  +10180-4.146656*T;     6000 N !
+
+ PARAMETER G(LIQUID,CR,FE,NI;0) 300 +130000-50*T;         6000 N !
+ PARAMETER G(LIQUID,CR,FE,NI;1) 300 +80000-50*T;          6000 N !
+ PARAMETER G(LIQUID,CR,FE,NI;2) 300 +60000-50*T;          6000 N !
+
+
+PHASE BCC_A2  %'  2 1   3 !
+CONSTITUENT BCC_A2  : CR,FE,NI : VA :  !
+
+ PARAMETER G(BCC_A2,CR:VA;0)      300 +GBCCCR;             6000 N !
+ PARAMETER G(BCC_A2,FE:VA;0)      300 +GBCCFE;             6000 N !
+ PARAMETER G(BCC_A2,NI:VA;0)      300 +GBCCNI;             3000 N !
+ PARAMETER TC(BCC_A2,CR:VA;0)     300 -311.5;              6000 N !
+ PARAMETER TC(BCC_A2,FE:VA;0)     300 +1043;               6000 N !
+ PARAMETER TC(BCC_A2,NI:VA;0)     300 +575;                6000 N !
+ PARAMETER BMAGN(BCC_A2,CR:VA;0)  300 -0.008;              6000 N !
+ PARAMETER BMAGN(BCC_A2,FE:VA;0)  300 +2.22;               6000 N !
+ PARAMETER BMAGN(BCC_A2,NI:VA;0)  300 +0.85;               6000 N !
+
+ PARAMETER TC(BCC_A2,CR,FE:VA;0)  300 +1650;               6000 N !
+ PARAMETER TC(BCC_A2,CR,FE:VA;1)  300 +550;                6000 N !
+ PARAMETER TC(BCC_A2,CR,NI:VA;0)  300 +2373;               6000 N !
+ PARAMETER TC(BCC_A2,CR,NI:VA;1)  300 +617;                6000 N !
+ PARAMETER TC(BCC_A2,FE,NI:VA;0)    300 +ZERO;             6000 N !
+ PARAMETER BMAGN(BCC_A2,CR,FE:VA;0) 300 -0.85;             6000 N !
+ PARAMETER BMAGN(BCC_A2,CR,NI:VA;0) 300 +4;                6000 N !
+ PARAMETER BMAGN(BCC_A2,FE,NI:VA;0) 300 +ZERO;             6000 N !
+
+ PARAMETER G(BCC_A2,CR,FE:VA;0)   300 +20500-9.68*T;       6000 N !
+ PARAMETER G(BCC_A2,CR,NI:VA;0)   300 +17170-11.8199*T;    6000 N !
+ PARAMETER G(BCC_A2,CR,NI:VA;1)   300 +34418-11.8577*T;    6000 N !
+ PARAMETER G(BCC_A2,FE,NI:VA;0)   300 -956.63-1.28726*T;   6000 N !
+ PARAMETER G(BCC_A2,FE,NI:VA;1)   300 +1789.03-1.92912*T;  6000 N !
+
+ PARAMETER G(BCC_A2,CR,FE,NI:VA;0) 300 +6000.+10*T;        6000 N !
+ PARAMETER G(BCC_A2,CR,FE,NI:VA;1) 300 -18500+10*T;        6000 N !
+ PARAMETER G(BCC_A2,CR,FE,NI:VA;2) 300 -27000+10*T;        6000 N !
+
+Phase FCC_A1 %( 2  1  1  !
+Constituent FCC_A1 : CR,FE,NI : VA : !
+
+ PARAMETER G(FCC_A1,CR:VA;0)      300  +GFCCCR;             6000 N !
+ PARAMETER G(FCC_A1,FE:VA;0)      300  +GFCCFE;             6000 N !
+ PARAMETER G(FCC_A1,NI:VA;0)      300  +GFCCNI;             3000 N !
+ PARAMETER TC(FCC_A1,CR:VA;0)     300  -1109;               6000 N !
+ PARAMETER TC(FCC_A1,FE:VA;0)     300  -201;                6000 N !
+ PARAMETER TC(FCC_A1,NI:VA;0)     300  +633;                6000 N !
+ PARAMETER BMAGN(FCC_A1,CR:VA;0)  300  -2.46;               6000 N !
+ PARAMETER BMAGN(FCC_A1,FE:VA;0)  300  -2.1;                6000 N !
+ PARAMETER BMAGN(FCC_A1,NI:VA;0)  300  +0.52;               6000 N !
+
+ PARAMETER TC(FCC_A1,CR,FE:VA;0)    300  +UN_ASS;           6000 N !
+ PARAMETER TC(FCC_A1,CR,NI:VA;0)    300  -3605;             6000 N !
+ PARAMETER TC(FCC_A1,FE,NI:VA;0)    300  +2133;             6000 N !
+ PARAMETER TC(FCC_A1,FE,NI:VA;1)    300  -682;              6000 N !
+ PARAMETER BMAGN(FCC_A1,CR,FE:VA;0) 300  +UN_ASS;           6000 N !
+ PARAMETER BMAGN(FCC_A1,CR,NI:VA;0) 300  -1.91;             6000 N !
+ PARAMETER BMAGN(FCC_A1,FE,NI:VA;0) 300  +9.55;             6000 N !
+ PARAMETER BMAGN(FCC_A1,FE,NI:VA;1) 300  +7.23;             6000 N !
+ PARAMETER BMAGN(FCC_A1,FE,NI:VA;2) 300  +5.93;             6000 N !
+ PARAMETER BMAGN(FCC_A1,FE,NI:VA;3) 300  +6.18;             6000 N !
+
+ PARAMETER G(FCC_A1,CR,FE:VA;0)  300 +10833-7.477*T;        6000 N !
+ PARAMETER G(FCC_A1,CR,FE:VA;1)  300 +1410;                 6000 N !
+ PARAMETER G(FCC_A1,CR,NI:VA;0)  300 +8030-12.8801*T;       6000 N !
+ PARAMETER G(FCC_A1,CR,NI:VA;1)  300 +33080-16.0362*T;      6000 N !
+ PARAMETER G(FCC_A1,FE,NI:VA;0)  300 -12054.355+3.27413*T;  6000 N !
+ PARAMETER G(FCC_A1,FE,NI:VA;1)  300 +11082.1315-4.4507*T;  6000 N !
+ PARAMETER G(FCC_A1,FE,NI:VA;2)  300 -725.805174;           6000 N !
+
+ PARAMETER G(FCC_A1,CR,FE,NI:VA;0) 300 +10000+10*T;         6000 N !
+ PARAMETER G(FCC_A1,CR,FE,NI:VA;1) 300 -6500;               6000 N !
+ PARAMETER G(FCC_A1,CR,FE,NI:VA;2) 300 +48000;              6000 N !
+
+
+"""
+
+CR_NI_TDB = """
+Element VA                VACUUM         0         0         0  !
+ELEMENT CR                BCC_A2    51.996      4050    23.560  !
+Element NI                FCC_A1    58.69       4787    29.7955 !
+
+FUNCTION GLIQCR  300 +15483.015+146.059775*T-26.908*T*LN(T)
+   +.00189435*T**2-1.47721E-06*T**3+139250*T**(-1)+2.37615E-21*T**7;  2180 Y
+   -16459.984+335.616316*T-50*T*LN(T);                                6000 N !
+FUNCTION GBCCCR  300 -8856.94+157.48*T
+ -26.908*T*LN(T)+.00189435*T**2-1.47721E-06*T**3+139250*T**(-1);      2180 Y
+  -34869.344+344.18*T-50*T*LN(T)-2.885261E+32*T**(-9);                6000 N !
+FUNCTION GFCCCR  300 -1572.94+157.643*T
+ -26.908*T*LN(T)+.00189435*T**2-1.47721E-06*T**3+139250*T**(-1);      2180 Y
+  -27585.344+344.343*T-50*T*LN(T)-2.885261E+32*T**(-9);               6000 N !
+FUNCTION GFCCNI  300 -5179.159+117.854*T
+      -22.096*T*ln(T)-0.0048407*T**2;                                 1728 Y
+      -27840.655+279.135*T-43.1*T*ln(T)+1.12754e+031*T**(-9);         3000 N !
+FUNCTION GLIQNI  300  11235.527+108.457*T-22.096*T*ln(T)
+      -0.0048407*T**2-3.82318e-021*T**7;                              1728 Y
+      -9549.775+268.598*T-43.1*T*ln(T);                               3000 N !
+FUNCTION GBCCNI     300  +8715.084-3.556*T+GFCCNI;                    6000 N !
+
+FUNCTION ZERO       300  +0;                                          6000 N !
+FUNCTION UN_ASS     300  +0;                                          6000 N !
+
+
+TYPE_DEFINITION % SEQ * !
+DEFINE_SYSTEM_DEFAULT ELEMENT 2 !
+
+TYPE_DEFINITION ' GES A_P_D BCC_A2 MAGNETIC  -1    0.4  !
+Type_Definition ( GES A_P_D FCC_A1 Magnetic  -3    0.28 !
+
+ Phase LIQUID % 1 1 !
+ Constituent LIQUID : CR,NI : !
+
+ PARAMETER G(LIQUID,CR;0)     300  +GLIQCR;               6000 N !
+ PARAMETER G(LIQUID,NI;0)     300  +GLIQNI;               6000 N !
+
+ PARAMETER G(LIQUID,CR,NI;0)  300  +318-7.3318*T;         6000 N !
+ PARAMETER G(LIQUID,CR,NI;1)  300  +16941-6.3696*T;       6000 N !
+
+PHASE BCC_A2  %'  2 1   3 !
+CONSTITUENT BCC_A2  : CR,NI : VA :  !
+
+ PARAMETER G(BCC_A2,CR:VA;0)      300 +GBCCCR;             6000 N !
+ PARAMETER G(BCC_A2,NI:VA;0)      300 +GBCCNI;             3000 N !
+ PARAMETER TC(BCC_A2,CR:VA;0)     300 -311.5;              6000 N !
+ PARAMETER TC(BCC_A2,NI:VA;0)     300 +575;                6000 N !
+ PARAMETER BMAGN(BCC_A2,CR:VA;0)  300 -0.008;              6000 N !
+ PARAMETER BMAGN(BCC_A2,NI:VA;0)  300 +0.85;               6000 N !
+
+ PARAMETER TC(BCC_A2,CR,NI:VA;0)  300 +2373;               6000 N !
+ PARAMETER TC(BCC_A2,CR,NI:VA;1)  300 +617;                6000 N !
+ PARAMETER BMAGN(BCC_A2,CR,NI:VA;0) 300 +4;                6000 N !
+
+ PARAMETER G(BCC_A2,CR,NI:VA;0)   300 +17170-11.8199*T;    6000 N !
+ PARAMETER G(BCC_A2,CR,NI:VA;1)   300 +34418-11.8577*T;    6000 N !
+
+Phase FCC_A1 %( 2  1  1  !
+Constituent FCC_A1 : CR,NI : VA : !
+
+ PARAMETER G(FCC_A1,CR:VA;0)      300  +GFCCCR;             6000 N !
+ PARAMETER G(FCC_A1,NI:VA;0)      300  +GFCCNI;             3000 N !
+ PARAMETER TC(FCC_A1,CR:VA;0)     300  -1109;               6000 N !
+ PARAMETER TC(FCC_A1,NI:VA;0)     300  +633;                6000 N !
+ PARAMETER BMAGN(FCC_A1,CR:VA;0)  300  -2.46;               6000 N !
+ PARAMETER BMAGN(FCC_A1,NI:VA;0)  300  +0.52;               6000 N !
+
+ PARAMETER TC(FCC_A1,CR,NI:VA;0)    300  -3605;             6000 N !
+ PARAMETER BMAGN(FCC_A1,CR,NI:VA;0) 300  -1.91;             6000 N !
+
+ PARAMETER G(FCC_A1,CR,NI:VA;0)  300 +8030-12.8801*T;       6000 N !
+ PARAMETER G(FCC_A1,CR,NI:VA;1)  300 +33080-16.0362*T;      6000 N !
+
+
+"""
+


### PR DESCRIPTION
If a user wants to fit a subsystem of their database, this code and tests ensures that everything still works.

In summary:

* Activity data works as normal. For activity data, the phases come from the dataset. All active phases are filtered through pycalphad's `filter_phases` function, to ensue that no phases that cannot be active with the components subset are active.
* Non-equilibrium thermochemical data: extra internal degrees of freedom are padded as zeros when constructing points.
