### PR TITLE
FIX: Update `truncate_arrays` and `optimal_parameters` to allow some zeros

### DIFF
--- a/espei/analysis.py
+++ b/espei/analysis.py
@@ -4,6 +4,7 @@ Tools for analyzing ESPEI runs
 
 import numpy as np
 
+
 def truncate_arrays(trace_array, prob_array=None):
     """
     Return slides of ESPEI output arrays with any empty remaining iterations (zeros) removed.
@@ -21,13 +22,20 @@ def truncate_arrays(trace_array, prob_array=None):
         A slide of the zeros-removed trace array is returned if only the trace
         is passed. Otherwise a tuple of both the trace and lnprob are returned.
 
+    Examples
+    --------
+    >>> from espei.analysis import truncate_arrays
+    >>> trace = np.array([[[1, 0], [2, 0], [3, 0], [0, 0]], [[0, 2], [0, 4], [0, 6], [0, 0]]])  # 3 iterations of 4 allocated
+    >>> truncate_arrays(trace).shape
+    (2, 3, 2)
+
     """
-    nz = np.nonzero(np.all(trace_array != 0, axis=-1))
+    nz = np.nonzero(np.any(trace_array != 0, axis=-1))
     s = trace_array.shape
     # number of iterations that are non-zero
     iterations = trace_array[nz].reshape(s[0], -1, s[2]).shape[1]
 
     if prob_array is None:
-        return trace_array[:,:iterations,:]
+        return trace_array[:, :iterations, :]
     else:
-        return trace_array[:,:iterations,:], prob_array[:, :iterations]
+        return trace_array[:, :iterations, :], prob_array[:, :iterations]

--- a/espei/optimizers/opt_mcmc.py
+++ b/espei/optimizers/opt_mcmc.py
@@ -67,9 +67,25 @@ class EmceeOptimizer(OptimizerBase):
         Returns
         -------
         ndarray
+
+        Notes
+        -----
+        Parameters are sampled from ``normal(loc=param, scale=param*std_deviation)``.
+        A parameter of zero will produce a standard deviation of zero and
+        therefore only zeros will be sampled. This will break emcee's
+        StretchMove for this parameter and only zeros will be selected.
+
         """
         logging.log(TRACE, 'Initial parameters: {}'.format(params))
         params = np.array(params)
+        num_zero_params = np.nonzero(params == 0)[0].size
+        if num_zero_params > 0:
+            logging.warning(f"{num_zero_params} initial parameter{' is' if num_zero_params == 1 else 's are'} "
+                            "initialized to zero. The ensemble of chains for zero parameters will be all initialized "
+                            "to zero and all proposed values for these parameter will be zero. If possible, it's "
+                            "better to make a good guess at a reasonable parameter value to start with. "
+                            "Alternatively, you can start with a small value near zero and let the ensemble search "
+                            "parameter space.")
         nchains = params.size * chains_per_parameter
         logging.info('Initializing {} chains with {} chains per parameter.'.format(nchains, chains_per_parameter))
         if deterministic:

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -91,9 +91,18 @@ def optimal_parameters(trace_array, lnprob_array, kth=0):
     It is ok if the calculation did not finish and the arrays are padded with
     zeros. The number of chains and iterations in the trace and lnprob arrays
     must match.
+
+    Examples
+    --------
+    >>> from espei.utils import optimal_parameters
+    >>> trace = np.array([[[1, 0], [2, 0], [3, 0], [0, 0]], [[0, 2], [0, 4], [0, 6], [0, 0]]])  # 3 iterations of 4 allocated
+    >>> lnprob = np.array([[-6, -4, -2, 0], [-3, -1, -2, 0]])
+    >>> np.all(np.isclose(optimal_parameters(trace, lnprob), np.array([0, 4])))
+    True
+
     """
     # indicies of chains + iterations that have non-zero parameters (that step has run)
-    nz = np.nonzero(np.all(trace_array != 0, axis=-1))
+    nz = np.nonzero(np.any(trace_array != 0, axis=-1))
     # chain + iteration index with the highest likelihood
     unique_params = np.zeros(trace_array.shape[-1])
     unique_params_found = -1


### PR DESCRIPTION
Users who had any zeros in their initial parameters would see an error when calling `optimal_parameters` ending in:

```python
  File "/Users/brandon/Projects/espei/espei/utils.py", line 110, in optimal_parameters
    for i in range(nz[-1][-1]):

IndexError: index -1 is out of bounds for axis 0 with size 0
```

The trace and lnprob arrays are initialized to zeros, so an intermediate trace or lnprob will be back-padded with zeros. This issue (and a corresponding issue in `truncate_arrays`) was caused by the code for finding the last iteration checking that `all` parameters were non-zero, when a more appropriate heuristic for finding the last iteration is to check that `any` parameters are non-zero. Note that `truncate_arrays` would fail silently, removing all the iterations from the trace (and probability, if passed). This is fixed so if some parameters are zero, `optimal_parameters` and `truncate_arrays` still work. Doctests were written for each to prevent regressions.

This issue could occur if an initial parameter passed by a user was zero, since the chains in the ensemble for that parameter are all initialized to zero and any StretchMove made by emcee for that parameter will also produce a zero. This is still allowed, however a warning is now logged so users have feedback on this nuance. The logged warning suggests to provide an initial parameter value that's either a good guess or close to zero.

A future solution would be to give users more flexible options for initializing parameters, such as the system for prior specification. Until a better solution exists, a user who desire parameter values centered at zero could work around this by providing a `restart_trace` (see the [input YAML docs](https://github.com/PhasesResearchLab/ESPEI/blob/master/docs/writing_input.rst)) that was made by hand, where the last iteration (just one iteration is sufficient) with all the chains they desire. Each parameter could be initialized to any distribution, for example a normal distribution centered at zero with a standard deviation of 10,000 J.