### PR TITLE
Preliminary support for thermochemical error for arbitrary properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.2' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine 'cyipopt>=0.1.9=*_1002'
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine 'ipopt<1.13'
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine 'ipopt<3.13'
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.2' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine 'cyipopt>=0.1.9=*_1002'
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,12 @@ install:
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then cd pycalphad-dev; fi
-  - if [[ $PYCALPHAD_DEVELOP ]]; then pip install -e . ; fi
+  - if [[ $PYCALPHAD_DEVELOP ]]; then pip install --no-deps -e . ; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then cd .. ; fi
 
 before_script:
   - source activate espei-env
-  - pip install -e '.[dev]'
+  - pip install --no-deps -e '.[dev]'
   - echo '!!! Installed packages'
   - conda list
   - echo '!!! Local directory'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - conda info -a
   - conda create -q -n espei-env python=$TRAVIS_PYTHON_VERSION
   - source activate espei-env
-  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine
+  - conda install -c conda-forge -c pycalphad 'pycalphad>=0.8.1' numpy scipy 'sympy' six 'dask>=2' 'distributed>=2' 'tinydb>=3.8' scikit-learn 'emcee<3' pyyaml cerberus bibtexparser sphinx sphinx_rtd_theme pytest nose mock twine 'ipopt<1.13'
   # If pycalphad develop is defined, uninstall the release and install the development version from github
   - if [[ $PYCALPHAD_DEVELOP ]]; then conda remove --force --yes pycalphad; fi
   - if [[ $PYCALPHAD_DEVELOP ]]; then git clone https://github.com/pycalphad/pycalphad pycalphad-dev; fi

--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -45,6 +45,8 @@ def check_dataset(dataset):
     is_activity = dataset['output'].startswith('ACR')
     is_zpf = dataset['output'] == 'ZPF'
     is_single_phase = 'solver' in dataset.keys()
+    if not any((is_equilibrium, is_single_phase, is_zpf)):
+        raise DatasetError("Cannot determine type of dataset")
     components = dataset['components']
     conditions = dataset['conditions']
     values = dataset['values']

--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -41,9 +41,10 @@ def check_dataset(dataset):
     DatasetError
         If an error is found in the dataset
     """
+    is_equilibrium = 'solver' not in dataset.keys() and dataset['output'] != 'ZPF'
     is_activity = dataset['output'].startswith('ACR')
     is_zpf = dataset['output'] == 'ZPF'
-    is_single_phase = (not is_zpf) and (not is_activity)
+    is_single_phase = 'solver' in dataset.keys()
     components = dataset['components']
     conditions = dataset['conditions']
     values = dataset['values']
@@ -60,16 +61,21 @@ def check_dataset(dataset):
             sublattice_occupancies = [None]*len(sublattice_configurations)
         elif sublattice_occupancies is None:
             raise DatasetError('At least one sublattice in the following sublattice configurations is mixing, but the "sublattice_occupancies" key is empty: {}'.format(sublattice_configurations))
-    if is_activity:
+    if is_equilibrium:
         conditions = dataset['conditions']
-        ref_state = dataset['reference_state']
         comp_conditions = {k: v for k, v in conditions.items() if k.startswith('X_')}
+    if is_activity:
+        ref_state = dataset['reference_state']
+    elif is_equilibrium:
+        for el, vals in dataset.get('reference_states', {}).items():
+            if 'phase' not in vals:
+                raise DatasetError(f'Reference state for element {el} must define the `phase` key with the reference phase name.')
 
 
     # check that the shape of conditions match the values
     num_pressure = np.atleast_1d(conditions['P']).size
     num_temperature = np.atleast_1d(conditions['T']).size
-    if is_activity:
+    if is_equilibrium:
         values_shape = np.array(values).shape
         # check each composition condition is the same shape
         num_x_conds = [len(v) for _, v in comp_conditions.items()]
@@ -111,7 +117,7 @@ def check_dataset(dataset):
                 else:
                     components_used.add(sl)
         comp_dof = 0
-    elif is_activity:
+    elif is_equilibrium:
         components_used.update({c.split('_')[1] for c in comp_conditions.keys()})
         # mass balance of components
         comp_dof = len(comp_conditions.keys())

--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -71,7 +71,6 @@ def check_dataset(dataset):
             if 'phase' not in vals:
                 raise DatasetError(f'Reference state for element {el} must define the `phase` key with the reference phase name.')
 
-
     # check that the shape of conditions match the values
     num_pressure = np.atleast_1d(conditions['P']).size
     num_temperature = np.atleast_1d(conditions['T']).size

--- a/espei/error_functions/__init__.py
+++ b/espei/error_functions/__init__.py
@@ -5,3 +5,4 @@ Functions for calculating error.
 from .activity_error import calculate_activity_error
 from .non_equilibrium_thermochemical_error import calculate_non_equilibrium_thermochemical_probability, get_thermochemical_data
 from .zpf_error import calculate_zpf_error, get_zpf_data
+from .equilibrium_thermochemical_error import calculate_equilibrium_thermochemical_probability, get_equilibrium_thermochemical_data

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -6,7 +6,7 @@ import sympy
 from pycalphad import variables as v
 from pycalphad.codegen.callables import build_callables
 from pycalphad.core.utils import instantiate_models
-from espei.error_functions import get_zpf_data, get_thermochemical_data
+from espei.error_functions import get_zpf_data, get_thermochemical_data, get_equilibrium_thermochemical_data
 from espei.utils import database_symbols_to_fit
 
 TRACE = 15
@@ -73,6 +73,11 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=data_weights, symbols_to_fit=symbols_to_fit)
     t2 = time.time()
     logging.log(TRACE, 'Finished getting non-equilibrium thermochemical data ({:0.2f}s)'.format(t2-t1))
+    logging.log(TRACE, 'Getting equilibrium thermochemical data (this may take some time)')
+    t1 = time.time()
+    eq_thermochemical_data = get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, parameters)
+    t2 = time.time()
+    logging.log(TRACE, 'Finished getting equilibrium thermochemical data ({:0.2f}s)'.format(t2-t1))
     logging.log(TRACE, 'Getting ZPF data (this may take some time)')
     t1 = time.time()
     zpf_data = get_zpf_data(dbf, comps, phases, datasets, parameters)
@@ -87,6 +92,9 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
         'zpf_kwargs': {
             'zpf_data': zpf_data,
             'data_weight': data_weights.get('ZPF', 1.0),
+        },
+        'equilibrium_thermochemical_kwargs': {
+            'eq_thermochemical_data': eq_thermochemical_data,
         },
         'thermochemical_kwargs': {
             'dbf': dbf, 'thermochemical_data': thermochemical_data,

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -84,7 +84,6 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
     t2 = time.time()
     logging.log(TRACE, 'Finished getting ZPF data ({:0.2f}s)'.format(t2-t1))
 
-
     # context for the log probability function
     # for all cases, parameters argument addressed in MCMC loop
     error_context = {

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -75,7 +75,7 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
     logging.log(TRACE, 'Finished getting non-equilibrium thermochemical data ({:0.2f}s)'.format(t2-t1))
     logging.log(TRACE, 'Getting equilibrium thermochemical data (this may take some time)')
     t1 = time.time()
-    eq_thermochemical_data = get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, parameters)
+    eq_thermochemical_data = get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, parameters, data_weight_dict=data_weights)
     t2 = time.time()
     logging.log(TRACE, 'Finished getting equilibrium thermochemical data ({:0.2f}s)'.format(t2-t1))
     logging.log(TRACE, 'Getting ZPF data (this may take some time)')

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -78,7 +78,8 @@ def build_eqpropdata(data, dbf, parameters=None):
     rav_comp_conds = [OrderedDict(zip(comp_conds.keys(), pt_comps)) for pt_comps in zip(*comp_conds.values())]
 
     # Build weights, should be the same size as the values
-    dataset_weights = np.array(data.get('weight', 1.0)) * np.ones(len(rav_comp_conds))
+    total_num_calculations = len(rav_comp_conds)*np.prod([len(vals) for vals in pot_conds.values()])
+    dataset_weights = np.array(data.get('weight', 1.0)) * np.ones(total_num_calculations)
     weights = (property_std_deviation.get(property_output, 1.0)/dataset_weights).flatten()
 
     # 'dbf', 'species', 'phases', 'potential_conds', 'composition_conds', 'models', 'phase_records', 'output', 'samples', 'weights'

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -151,6 +151,11 @@ def calc_prop_differences(eqpropdata: EqPropData,
         multi_eqdata = _equilibrium(species, phase_records, cond_dict, grid)
         # TODO: could be kind of slow. Callables (which are cachable) must be built.
         propdata = _eqcalculate(dbf, species, phases, cond_dict, output, data=multi_eqdata, per_phase=False, callables=None, parameters=params_dict, model=models)
+        print(cond_dict)
+        print(propdata[output])
+        print(multi_eqdata['Phase'])
+        print(multi_eqdata['Y'])
+
 
         if 'vertex' in propdata.data_vars[output][0]:
             raise ValueError("Property {output} cannot be used to calculate equilibrium thermochemical error because each phase has a unique value for this property.")

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -4,7 +4,7 @@ Calculate error due to equilibrium thermochemical properties.
 
 import logging
 from collections import OrderedDict
-from typing import NamedTuple, Sequence, Dict, Optional
+from typing import NamedTuple, Sequence, Dict, Optional, Tuple
 
 import numpy as np
 import tinydb
@@ -38,8 +38,8 @@ EqPropData = NamedTuple('EqPropData', (('dbf', Database),
 
 def build_eqpropdata(data: tinydb.database.Document,
                      dbf: Database,
-                     parameters: Optional(Dict[str, float]) = None,
-                     data_weight_dict: Optional(Dict[str, float]) = None
+                     parameters: Optional[Dict[str, float]] = None,
+                     data_weight_dict: Optional[Dict[str, float]] = None
                      ) -> EqPropData:
     """
     Build EqPropData for the calculations corresponding to a single dataset.
@@ -50,9 +50,9 @@ def build_eqpropdata(data: tinydb.database.Document,
         Document corresponding to a single ESPEI dataset.
     dbf : Database
         Database that should be used to construct the `Model` and `PhaseRecord` objects.
-    parameters : Optional(Dict[str, float])
+    parameters : Optional[Dict[str, float]]
         Mapping of parameter symbols to values.
-    data_weight_dict : Optional(Dict[str, float])
+    data_weight_dict : Optional[Dict[str, float]]
         Mapping of a data type (e.g. `HM` or `SM`) to a weight.
 
     Returns
@@ -112,8 +112,8 @@ def build_eqpropdata(data: tinydb.database.Document,
 def get_equilibrium_thermochemical_data(dbf: Database, comps: Sequence[str],
                                         phases: Sequence[str],
                                         datasets: PickleableTinyDB,
-                                        parameters: Optional(Dict[str, float]) = None,
-                                        data_weight_dict: Optional(Dict[str, float]) = None,
+                                        parameters: Optional[Dict[str, float]] = None,
+                                        data_weight_dict: Optional[Dict[str, float]] = None,
                                         ) -> Sequence[EqPropData]:
     """
     Get all the EqPropData for each matching equilibrium thermochemical dataset in the datasets
@@ -128,9 +128,9 @@ def get_equilibrium_thermochemical_data(dbf: Database, comps: Sequence[str],
         List of phases used to search for matching datasets.
     datasets : PickleableTinyDB
         Datasets that contain single phase data
-    parameters : Optional(Dict[str, float])
+    parameters : Optional[Dict[str, float]]
         Mapping of parameter symbols to values.
-    data_weight_dict : Optional(Dict[str, float])
+    data_weight_dict : Optional[Dict[str, float]]
         Mapping of a data type (e.g. `HM` or `SM`) to a weight.
 
     Notes
@@ -161,9 +161,29 @@ def get_equilibrium_thermochemical_data(dbf: Database, comps: Sequence[str],
 
 def calc_prop_differences(eqpropdata: EqPropData,
                           parameters: np.ndarray,
-                          approximate_equilibrium: bool = False,
-                          ) -> np.ndarray:
+                          approximate_equilibrium: Optional[bool] = False,
+                          ) -> Tuple[np.ndarray, np.ndarray]:
     """
+    Calculate differences between the expected and calculated values for a property
+
+    Parameters
+    ----------
+    eqpropdata : EqPropData
+        Data corresponding to equilibrium calculations for a single datasets.
+    parameters : np.ndarray
+        Array of parameters to fit. Must be sorted in the same symbol sorted
+        order used to create the PhaseRecords.
+    approximate_equilibrium : Optional[bool]
+        Whether or not to use an approximate version of equilibrium that does
+        not refine the solution and uses ``starting_point`` instead.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        Pair of
+        * differences between the calculated property and expected property
+        * weights for this dataset
+
     """
     if approximate_equilibrium:
         _equilibrium = no_op_equilibrium_

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -79,7 +79,7 @@ def build_eqpropdata(data, dbf, parameters=None):
 
     # Build weights, should be the same size as the values
     dataset_weights = np.array(data.get('weight', 1.0)) * np.ones(len(rav_comp_conds))
-    weights = property_std_deviation.get(property_output, 1.0)/dataset_weights
+    weights = (property_std_deviation.get(property_output, 1.0)/dataset_weights).flatten()
 
     # 'dbf', 'species', 'phases', 'potential_conds', 'composition_conds', 'models', 'phase_records', 'output', 'samples', 'weights'
     return EqPropData(dbf, species, data_phases, pot_conds, rav_comp_conds, models, parameters, phase_records, output, samples, weights, reference)
@@ -155,8 +155,8 @@ def calc_prop_differences(eqpropdata: EqPropData,
 
     calculated_data = np.array(calculated_data, dtype=np.float)
 
-    assert calculated_data.shape == samples.shape
-    assert calculated_data.shape == weights.shape
+    assert calculated_data.shape == samples.shape, f"Calculated data shape {calculated_data.shape} does not match samples shape {samples.shape}"
+    assert calculated_data.shape == weights.shape, f"Calculated data shape {calculated_data.shape} does not match weights shape {weights.shape}"
     differences = calculated_data - samples
     logging.debug('Equilibrium thermochemical error - differences: {}, weights: {}, reference: {}'.format(differences, weights, eqpropdata.reference))
     return differences, weights

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -200,6 +200,10 @@ def calculate_equilibrium_thermochemical_probability(eq_thermochemical_data: Seq
     weights = []
     for eqpropdata in eq_thermochemical_data:
         diffs, wts = calc_prop_differences(eqpropdata, parameters, approximate_equilibrium)
+        if not errors and np.any(np.isinf(diffs) | np.isnan(diffs)):
+            # NaN or infinity are assumed calculation failures. If we are
+            # calculating log-probability, just bail out and return -infinity.
+            return -np.inf
         differences.append(diffs)
         weights.append(wts)
 

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -134,7 +134,7 @@ def calc_prop_differences(eqpropdata: EqPropData,
     models = eqpropdata.models
     phase_records = eqpropdata.phase_records
     update_phase_record_parameters(phase_records, parameters)
-    params_dict = OrderedDict(zip(eqpropdata.params_keys, parameters))
+    params_dict = OrderedDict(zip(map(str, eqpropdata.params_keys), parameters))
     output = eqpropdata.output
     weights = np.array(eqpropdata.weight, dtype=np.float)
     samples = np.array(eqpropdata.samples, dtype=np.float)
@@ -162,7 +162,7 @@ def calc_prop_differences(eqpropdata: EqPropData,
     assert calculated_data.shape == samples.shape, f"Calculated data shape {calculated_data.shape} does not match samples shape {samples.shape}"
     assert calculated_data.shape == weights.shape, f"Calculated data shape {calculated_data.shape} does not match weights shape {weights.shape}"
     differences = calculated_data - samples
-    logging.debug('Equilibrium thermochemical error - differences: {}, weights: {}, reference: {}'.format(differences, weights, eqpropdata.reference))
+    logging.debug(f'Equilibrium thermochemical error - output: {output} differences: {differences}, weights: {weights}, reference: {eqpropdata.reference}')
     return differences, weights
 
 

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -165,8 +165,8 @@ def calc_prop_differences(eqpropdata: EqPropData,
 def calculate_equilibrium_thermochemical_probability(eq_thermochemical_data: Sequence[EqPropData],
                                                      parameters: Optional[np.ndarray],
                                                      approximate_equilibrium: bool = False,
-                                                     data_weight=1.0,
-                                                     errors=False):
+                                                     data_weight: float = 1.0,
+                                                     errors: bool = False):
     """
     Return the sum of square error from activity data
 

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from typing import NamedTuple, Sequence, Dict, Optional
 
 import numpy as np
+import tinydb
 from tinydb import where
 
 from pycalphad.plot.eqplot import _map_coord_to_variable
@@ -33,7 +34,29 @@ EqPropData = NamedTuple('EqPropData', (('dbf', Database),
                                        ))
 
 
-def build_eqpropdata(data, dbf, parameters=None, data_weight_dict=None):
+def build_eqpropdata(data: tinydb.database.Document,
+                     dbf: Database,
+                     parameters: Optional(Dict[str, float]) = None,
+                     data_weight_dict: Optional(Dict[str, float]) = None
+                     ) -> EqPropData:
+    """
+    Build EqPropData for the calculations corresponding to a single dataset.
+
+    Parameters
+    ----------
+    data : tinydb.database.Document
+        Document corresponding to a single ESPEI dataset.
+    dbf : Database
+        Database that should be used to construct the `Model` and `PhaseRecord` objects.
+    parameters : Optional(Dict[str, float])
+        Mapping of parameter symbols to values.
+    data_weight_dict : Optional(Dict[str, float])
+        Mapping of a data type (e.g. `HM` or `SM`) to a weight.
+
+    Returns
+    -------
+    EqPropData
+    """
     parameters = parameters if parameters is not None else {}
     data_weight_dict = data_weight_dict if data_weight_dict is not None else {}
     property_std_deviation = {

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -151,11 +151,6 @@ def calc_prop_differences(eqpropdata: EqPropData,
         multi_eqdata = _equilibrium(species, phase_records, cond_dict, grid)
         # TODO: could be kind of slow. Callables (which are cachable) must be built.
         propdata = _eqcalculate(dbf, species, phases, cond_dict, output, data=multi_eqdata, per_phase=False, callables=None, parameters=params_dict, model=models)
-        print(cond_dict)
-        print(propdata[output])
-        print(multi_eqdata['Phase'])
-        print(multi_eqdata['Y'])
-
 
         if 'vertex' in propdata.data_vars[output][0]:
             raise ValueError("Property {output} cannot be used to calculate equilibrium thermochemical error because each phase has a unique value for this property.")

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -151,6 +151,9 @@ def calc_prop_differences(eqpropdata: EqPropData,
         # TODO: could be kind of slow. Callables (which are cachable) must be built.
         propdata = _eqcalculate(dbf, species, phases, cond_dict, output, data=multi_eqdata, per_phase=False, callables=None, parameters=params_dict, model=models)
 
+        if 'vertex' in propdata.data_vars[output][0]:
+            raise ValueError("Property {output} cannot be used to calculate equilibrium thermochemical error because each phase has a unique value for this property.")
+
         vals = getattr(propdata, output).flatten().tolist()
         calculated_data.extend(vals)
 

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -67,7 +67,7 @@ def build_eqpropdata(data, dbf, parameters=None):
     pot_conds = OrderedDict([(getattr(v, key), unpack_condition(data['conditions'][key])) for key in sorted(data['conditions'].keys()) if not key.startswith('X_')])
     comp_conds = OrderedDict([(v.X(key[2:]), unpack_condition(data['conditions'][key])) for key in sorted(data['conditions'].keys()) if key.startswith('X_')])
 
-    phase_records = build_phase_records(dbf, species, data_phases, {**pot_conds, **comp_conds}, models, parameters=parameters)
+    phase_records = build_phase_records(dbf, species, data_phases, {**pot_conds, **comp_conds}, models, parameters=parameters, build_gradients=True, build_hessians=True)
 
     # Now we need to unravel the composition conditions
     # (from Dict[v.X, List[float]] to List[Dict[v.X, float]]), since the
@@ -79,7 +79,7 @@ def build_eqpropdata(data, dbf, parameters=None):
 
     # Build weights, should be the same size as the values
     dataset_weights = np.array(data.get('weight', 1.0)) * np.ones(len(rav_comp_conds))
-    weights = property_std_deviation[property_output]/dataset_weights
+    weights = property_std_deviation.get(property_output, 1.0)/dataset_weights
 
     # 'dbf', 'species', 'phases', 'potential_conds', 'composition_conds', 'models', 'phase_records', 'output', 'samples', 'weights'
     return EqPropData(dbf, species, data_phases, pot_conds, rav_comp_conds, models, parameters, phase_records, output, samples, weights, reference)

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -193,6 +193,9 @@ def calculate_equilibrium_thermochemical_probability(eq_thermochemical_data: Seq
         A single float of the sum of square errors
 
     """
+    if len(eq_thermochemical_data) == 0:
+        return 0.0
+
     differences = []
     weights = []
     for eqpropdata in eq_thermochemical_data:

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -1,0 +1,205 @@
+"""
+Calculate error due to equilibrium thermochemical properties.
+"""
+
+import logging
+from collections import OrderedDict
+from typing import NamedTuple, Sequence, Dict, Optional
+
+import numpy as np
+from tinydb import where
+
+from pycalphad.plot.eqplot import _map_coord_to_variable
+from scipy.stats import norm
+from pycalphad import Database, Model, ReferenceState, variables as v
+from pycalphad.core.equilibrium import _eqcalculate
+from pycalphad.codegen.callables import build_phase_records
+from pycalphad.core.utils import instantiate_models, filter_phases, unpack_components, unpack_condition
+from pycalphad.core.phase_rec import PhaseRecord
+from espei.utils import PickleableTinyDB
+from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters
+
+from espei.core_utils import ravel_conditions
+
+EqPropData = NamedTuple('EqPropData', (('dbf', Database),
+                                       ('species', Sequence[v.Species]),
+                                       ('phases', Sequence[str]),
+                                       ('potential_conds', Dict[v.StateVariable, float]),
+                                       ('composition_conds', Sequence[Dict[v.X, float]]),
+                                       ('models', Dict[str, Model]),
+                                       ('parameters', Dict[str, float]),
+                                       ('phase_records', Sequence[Dict[str, PhaseRecord]]),
+                                       ('output', str),
+                                       ('samples', np.ndarray),
+                                       ('weight', np.ndarray),
+                                       ('reference', str),
+                                       ))
+
+
+def build_eqpropdata(data, dbf, parameters=None):
+    property_std_deviation = {
+        'HM': 500.0,  # J/mol
+        'SM':   0.2,  # J/K-mol
+        'CPM':  0.2,  # J/K-mol
+    }
+
+    data_comps = list(set(data['components']).union({'VA'}))
+    species = sorted(unpack_components(dbf, data_comps), key=str)
+    data_phases = filter_phases(dbf, species, candidate_phases=data['phases'])
+    models = instantiate_models(dbf, species, data_phases, parameters=parameters)
+    output = data['output']
+    property_output = output.split('_')[0] # property without _FORM, _MIX, etc.
+    all_regions = data['values']
+    conditions = data['conditions']
+    samples = np.array(data['values']).flatten()
+    reference = data.get('reference', '')
+
+    # Models are now modified in response to the data from this data
+    if 'reference_states' in data:
+        property_output = output[:-1] if output.endswith('R') else output  # unreferenced model property so we can tell shift_reference_state what to build.
+        reference_states = []
+        for el, vals in data['reference_states'].items():
+            reference_states.append(ReferenceState(v.Species(el), vals['phase'], fixed_statevars=vals.get('fixed_state_variables')))
+        for mod in models.values():
+            mod.shift_reference_state(reference_states, dbf, output=(property_output,))
+
+    data['conditions'].setdefault('N', 1.0)  # Add default for N. Nothing else is supported in pycalphad anyway.
+    pot_conds = OrderedDict([(getattr(v, key), unpack_condition(data['conditions'][key])) for key in sorted(data['conditions'].keys()) if not key.startswith('X_')])
+    comp_conds = OrderedDict([(v.X(key[2:]), unpack_condition(data['conditions'][key])) for key in sorted(data['conditions'].keys()) if key.startswith('X_')])
+
+    phase_records = build_phase_records(dbf, species, data_phases, {**pot_conds, **comp_conds}, models, parameters=parameters)
+
+    # Now we need to unravel the composition conditions
+    # (from Dict[v.X, List[float]] to List[Dict[v.X, float]]), since the
+    # composition conditions are only broadcast against the potentials, not
+    # each other. Each individual composition needs to be computed
+    # independently, since broadcasting over composition cannot be turned off
+    # in pycalphad.
+    rav_comp_conds = [OrderedDict(zip(comp_conds.keys(), pt_comps)) for pt_comps in zip(*comp_conds.values())]
+
+    # Build weights, should be the same size as the values
+    dataset_weights = np.array(data.get('weight', 1.0)) * np.ones(len(rav_comp_conds))
+    weights = property_std_deviation[property_output]/dataset_weights
+
+    # 'dbf', 'species', 'phases', 'potential_conds', 'composition_conds', 'models', 'phase_records', 'output', 'samples', 'weights'
+    return EqPropData(dbf, species, data_phases, pot_conds, rav_comp_conds, models, parameters, phase_records, output, samples, weights, reference)
+
+
+def get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, parameters=None):
+    """
+
+    Parameters
+    ----------
+    dbf : pycalphad.Database
+        Database to consider
+    comps : list
+        List of active component names
+    phases : list
+        List of phases to consider
+    datasets : espei.utils.PickleableTinyDB
+        Datasets that contain single phase data
+    """
+    # From non_equilibrium_thermochemical_error
+
+    desired_data = datasets.search(
+        # data that isn't ZPF or non-equilibrium thermochemical
+        (where('output') != 'ZPF') & (~where('solver')) &
+        (where('output').test(lambda x: 'ACR' not in x)) &  # activity data not supported yet
+        (where('components').test(lambda x: set(x).issubset(comps))) &
+        (where('phases').test(lambda x: set(x).issubset(set(phases))))
+    )
+
+    eq_thermochemical_data = []  # 1:1 correspondence with each dataset
+    for data in desired_data:
+        eq_thermochemical_data.append(build_eqpropdata(data, dbf, parameters=parameters))
+    return eq_thermochemical_data
+
+
+def calc_prop_differences(eqpropdata: EqPropData,
+                          parameters: np.ndarray,
+                          approximate_equilibrium: bool = False,
+                          ) -> np.ndarray:
+    """
+    """
+    if approximate_equilibrium:
+        _equilibrium = no_op_equilibrium_
+    else:
+        _equilibrium = equilibrium_
+
+    dbf = eqpropdata.dbf
+    species = eqpropdata.species
+    phases = eqpropdata.phases
+    pot_conds = eqpropdata.potential_conds
+    models = eqpropdata.models
+    phase_records = eqpropdata.phase_records
+    update_phase_record_parameters(phase_records, parameters)
+    params_dict = eqpropdata.parameters
+    output = eqpropdata.output
+    weights = np.array(eqpropdata.weight, dtype=np.float)
+    samples = np.array(eqpropdata.samples, dtype=np.float)
+
+    calculated_data = []
+    for comp_conds in eqpropdata.composition_conds:
+        cond_dict = OrderedDict(**pot_conds, **comp_conds)
+        # Extract chemical potential hyperplane from multi-phase calculation
+        # Note that we consider all phases in the system, not just ones in this tie region
+        # str_statevar_dict must be sorted, assumes that pot_conds are.
+        str_statevar_dict = OrderedDict([(str(key), vals) for key, vals in pot_conds.items()])
+        grid = calculate_(dbf, species, phases, str_statevar_dict, models, phase_records, pdens=500, fake_points=True)
+        multi_eqdata = _equilibrium(species, phase_records, cond_dict, grid)
+        # TODO: could be kind of slow. Callables (which are cachable) must be built.
+        propdata = _eqcalculate(dbf, species, phases, cond_dict, output, data=multi_eqdata, per_phase=False, callables=None, parameters=params_dict, model=models)
+
+        vals = getattr(propdata, output).flatten().tolist()
+        calculated_data.extend(vals)
+
+    calculated_data = np.array(calculated_data, dtype=np.float)
+
+    assert calculated_data.shape == samples.shape
+    assert calculated_data.shape == weights.shape
+    differences = calculated_data - samples
+    logging.debug('Equilibrium thermochemical error - differences: {}, weights: {}, reference: {}'.format(differences, weights, eqpropdata.reference))
+    return differences, weights
+
+
+def calculate_equilibrium_thermochemical_probability(eq_thermochemical_data: Sequence[EqPropData],
+                                                     parameters: Optional[np.ndarray],
+                                                     approximate_equilibrium: bool = False,
+                                                     data_weight=1.0,
+                                                     errors=False):
+    """
+    Return the sum of square error from activity data
+
+    Parameters
+    ----------
+    eq_thermochemical_data : Sequence[EqPropData]
+    parameters : Optional[np.ndarray]
+        Values of parameters for this iteration to be updated in PhaseRecords.
+    data_weight : float
+        Weight for standard deviation for the data, dimensionless.
+    errors : bool
+        If True, a list of differences between data and calculated values are
+        returned, otherwise (the default) sum of all probabilities are
+        returned. This is useful for tests, where probabilities and default
+        standard deviations may change.
+
+    Returns
+    -------
+    float
+        A single float of the sum of square errors
+
+    """
+    differences = []
+    weights = []
+    for eqpropdata in eq_thermochemical_data:
+        diffs, wts = calc_prop_differences(eqpropdata, parameters, approximate_equilibrium)
+        differences.append(diffs)
+        weights.append(wts)
+
+    differences = np.concatenate(differences, axis=0)
+    if errors:
+        return differences
+    else:
+        weights = np.concatenate(weights, axis=0)
+        probs = norm(loc=0.0, scale=weights/data_weight).logpdf(differences)
+        return np.sum(probs)

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -177,7 +177,7 @@ def get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=None, symb
     all_data_dicts = []
     for phase_name in phases:
         for prop in properties:
-            desired_data = get_prop_data(comps, phase_name, prop, datasets)
+            desired_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=(where('solver')))
             if len(desired_data) == 0:
                 continue
             unique_exclusions = set([tuple(sorted(d.get('excluded_model_contributions', []))) for d in desired_data])
@@ -190,9 +190,9 @@ def get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=None, symb
                 }
                 # get all the data with these model exclusions
                 if exclusion == tuple([]):
-                    exc_search = ~where('excluded_model_contributions').exists()
+                    exc_search = (~where('excluded_model_contributions').exists()) & (where('solver'))
                 else:
-                    exc_search = where('excluded_model_contributions').test(lambda x: tuple(sorted(x)) == exclusion)
+                    exc_search = (where('excluded_model_contributions').test(lambda x: tuple(sorted(x)) == exclusion)) & (where('solver'))
                 curr_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=exc_search)
                 calculate_dict = get_prop_samples(dbf, comps, phase_name, curr_data)
                 mod = Model(dbf, comps, phase_name, parameters=symbols_to_fit)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -27,7 +27,7 @@ from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.utils import instantiate_models, filter_phases, unpack_components
 from pycalphad.core.phase_rec import PhaseRecord
 from espei.utils import PickleableTinyDB
-from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_
+from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters
 
 def _safe_index(items, index):
     try:
@@ -35,10 +35,6 @@ def _safe_index(items, index):
     except IndexError:
         return None
 
-def update_phase_record_parameters(phase_records: Dict[str, PhaseRecord], parameters: np.ndarray) -> None:
-    if parameters.size > 0:
-        for phase_name, phase_record in phase_records.items():
-            phase_record.parameters[:] = parameters
 
 def extract_conditions(all_conditions: Dict[v.StateVariable, np.ndarray], idx: int) -> Dict[v.StateVariable, float]:
     """Conditions are either scalar or 1d arrays for the conditions in the entire dataset.

--- a/espei/shadow_functions.py
+++ b/espei/shadow_functions.py
@@ -15,6 +15,13 @@ from pycalphad.core.utils import get_state_variables, unpack_kwarg, point_sample
 from pycalphad.core.light_dataset import LightDataset
 from pycalphad.core.calculate import _sample_phase_constitution, _compute_phase_values
 
+
+def update_phase_record_parameters(phase_records: Dict[str, PhaseRecord], parameters: np.ndarray) -> None:
+    if parameters.size > 0:
+        for phase_name, phase_record in phase_records.items():
+            phase_record.parameters[:] = parameters
+
+
 def calculate_(dbf: Database, species: Sequence[v.Species], phases: Sequence[str],
                str_statevar_dict: Dict[str, np.ndarray], models: Dict[str, Model],
                phase_records: Dict[str, PhaseRecord], output: Optional[str] = 'GM',

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from espei.datasets import DatasetError, check_dataset, clean_dataset
 
-from .testing_data import CU_MG_EXP_ACTIVITY, CU_MG_DATASET_THERMOCHEMICAL_STRING_VALUES, CU_MG_DATASET_ZPF_STRING_VALUES
+from .testing_data import CU_MG_EXP_ACTIVITY, CU_MG_DATASET_THERMOCHEMICAL_STRING_VALUES, CU_MG_DATASET_ZPF_STRING_VALUES, LI_SN_LIQUID_DATA
 from .fixtures import datasets_db
 
 dataset_single_valid = {
@@ -448,3 +448,11 @@ def test_check_datasets_raises_if_configs_occupancies_not_aligned(datasets_db):
     """Checking datasets that don't have the same number/shape of configurations/occupancies should raise."""
     with pytest.raises(DatasetError):
         check_dataset(dataset_mismatched_configs_occupancies)
+
+
+# Expected to fail, since the dataset checker cannot determine that species are used in the configurations and components should only contain pure elements.
+@pytest.mark.xfail
+def test_non_equilibrium_thermo_data_with_species_passes_checker():
+    """Non-equilibrium thermochemical data that use species in the configurations should pass the dataset checker.
+    """
+    check_dataset(LI_SN_LIQUID_DATA)

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -356,3 +356,26 @@ def test_equilibrium_thermochemical_error_unsupported_property(datasets_db):
     eqdata = get_equilibrium_thermochemical_data(dbf, ['CR', 'NI'], phases, datasets_db)
     errors_exact, weights = calc_prop_differences(eqdata[0], np.array([]))
     assert np.all(np.isclose(errors_exact, EXPECTED_VALUES, atol=1e-3))
+
+
+def test_equilibrium_thermochemical_error_computes_correct_probability(datasets_db):
+    """Integration test for equilibrium thermochemical error."""
+    datasets_db.insert(CU_MG_EQ_HMR_LIQUID)
+    dbf = Database(CU_MG_TDB)
+    phases = list(dbf.phases.keys())
+
+    # Test that errors update in response to changing parameters
+    # no parameters
+    eqdata = get_equilibrium_thermochemical_data(dbf, ['CU', 'MG'], phases, datasets_db)
+    errors, weights = calc_prop_differences(eqdata[0], np.array([]))
+    expected_vals = [-31626.6*0.5*0.5]
+    assert np.all(np.isclose(errors, expected_vals))
+
+    # VV0017 (LIQUID, L0)
+    eqdata = get_equilibrium_thermochemical_data(dbf, ['CU', 'MG'], phases, datasets_db, {'VV0017': -31626.6})
+    # unchanged, should be the same as before
+    errors, weights = calc_prop_differences(eqdata[0], np.array([-31626.6]))
+    assert np.all(np.isclose(errors, [-31626.6*0.5*0.5]))
+    # change to -40000
+    errors, weights = calc_prop_differences(eqdata[0], np.array([-40000], np.float))
+    assert np.all(np.isclose(errors, [-40000*0.5*0.5]))

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -336,6 +336,7 @@ def test_equilibrium_thermochemcial_error_species(datasets_db):
     # Thermo-Calc
     truth_values = np.array([0.0, -28133.588, -40049.995, 0.0])
     # Approximate
+    print(eqdata[0])
     errors_approximate, weights = calc_prop_differences(eqdata[0], np.array([]), True)
     # Looser rtol because the equilibrium is approximate
     assert np.all(np.isclose(errors_approximate, truth_values, atol=1e-6, rtol=1e-3))

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -307,3 +307,17 @@ def test_zpf_error_works_for_stoichiometric_cmpd_tielines(datasets_db):
     assert np.isclose(exact_likelihood, zero_error_probability, rtol=1e-6)
     approx_likelihood = calculate_zpf_error(zpf_data)
     assert np.isclose(approx_likelihood, zero_error_probability, rtol=1e-6)
+
+
+def test_non_equilibrium_thermochemcial_species(datasets_db):
+    """Test species work for non-equilibrium thermochemical data."""
+
+    datasets_db.insert(LI_SN_LIQUID_DATA)
+
+    dbf = Database(LI_SN_TDB)
+    phases = ['LIQUID']
+
+    thermochemical_data = get_thermochemical_data(dbf, ['LI', 'SN'], phases, datasets_db)
+    prob = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    # Near zero error and non-zero error
+    assert np.isclose(prob, (-7.13354663 + -22.43585011))

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -342,3 +342,17 @@ def test_equilibrium_thermochemcial_error_species(datasets_db):
     # Exact
     errors_exact, weights = calc_prop_differences(eqdata[0], np.array([]), False)
     assert np.all(np.isclose(errors_exact, truth_values, atol=1e-6))
+
+
+def test_equilibrium_thermochemical_error_unsupported_property(datasets_db):
+    """Test that an equilibrium property that is not explictly supported will work."""
+    # This test specifically tests Curie temperature
+    datasets_db.insert(CR_NI_LIQUID_EQ_TC_DATA)
+    EXPECTED_VALUES = np.array([374.6625, 0.0, 0.0])  # the TC should be 374.6625 in both cases, but "values" are [0 and 382.0214], so the differences should be flipped.
+
+    dbf = Database(CR_NI_TDB)
+    phases = list(dbf.phases.keys())
+
+    eqdata = get_equilibrium_thermochemical_data(dbf, ['CR', 'NI'], phases, datasets_db)
+    errors_exact, weights = calc_prop_differences(eqdata[0], np.array([]))
+    assert np.all(np.isclose(errors_exact, EXPECTED_VALUES, atol=1e-3))

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -336,7 +336,6 @@ def test_equilibrium_thermochemcial_error_species(datasets_db):
     # Thermo-Calc
     truth_values = np.array([0.0, -28133.588, -40049.995, 0.0])
     # Approximate
-    print(eqdata[0])
     errors_approximate, weights = calc_prop_differences(eqdata[0], np.array([]), True)
     # Looser rtol because the equilibrium is approximate
     assert np.all(np.isclose(errors_approximate, truth_values, atol=1e-6, rtol=1e-3))

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -321,3 +321,17 @@ def test_non_equilibrium_thermochemcial_species(datasets_db):
     prob = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
     # Near zero error and non-zero error
     assert np.isclose(prob, (-7.13354663 + -22.43585011))
+
+
+def test_equilibrium_thermochemcial_error_species(datasets_db):
+    """Test species work for equilibrium thermochemical data."""
+
+    datasets_db.insert(LI_SN_LIQUID_DATA)
+
+    dbf = Database(LI_SN_TDB)
+    phases = ['LIQUID']
+
+    thermochemical_data = get_thermochemical_data(dbf, ['LI', 'SN'], phases, datasets_db)
+    prob = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    # Near zero error and non-zero error
+    assert np.isclose(prob, (-7.13354663 + -22.43585011))

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -164,9 +164,6 @@ PARAMETER L(FCC_A1,CU,MG:VA;2) 1 VV0001#; 10000 N !
 CU_MG_EXP_ACTIVITY = yaml.load("""{
   "components": ["CU", "MG", "VA"],
   "phases": ["LIQUID"],
-  "solver": {
-    "mode": "manual",
-  },
   "reference_state": {
     "phases": ["LIQUID"],
     "conditions": {

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -1077,3 +1077,19 @@ LI_SN_ZPF_DATA = {
     ],
     "reference": "zpf test", "comment": "Exact tieline based on equilibrium calculation"
 }
+
+
+LI_SN_LIQUID_DATA = {
+    "components": ["LI", "SN"],
+    "phases": ["LIQUID"],
+    "solver": {
+        "mode": "manual",
+        "sublattice_site_ratios": [1],
+        "sublattice_configurations": [[["LI", "LI4SN"]], [["LI4SN", "SN"]]],
+        "sublattice_occupancies": [[[0.5, 0.5]], [[0.5, 0.5]]]
+    },
+    "conditions": {"P": 101325, "T": 300},
+    "output": "HM_MIX",
+    "values": [[[0, 0]]],
+    "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN"
+}

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -689,6 +689,17 @@ CR_NI_ACTIVITY = {
     "reference": "activity test", "comment": "Example, nearly ideal"
 }
 
+
+CR_NI_LIQUID_EQ_TC_DATA = {
+    "components": ["CR", "NI"],
+    "phases": ["FCC_A1"],
+    "conditions": {"P": 101325, "T": [500, 600, 700], "X_NI": 0.95},
+    "output": "TC",
+    "values": [[[0.0], [374.6625], [374.6625]]],
+    "reference": "equilibrium thermochemical tests", "comment": "Data checked by pycalphad. Values should be temperature independent and both temperature calulcations should give the 374.6625 value. Note, there's a low temperature miscibility gap (below 453 K)"
+}
+
+
 CR_FE_NI_TDB = """
 Element VA                VACUUM         0         0         0  !
 ELEMENT CR                BCC_A2    51.996      4050    23.560  !
@@ -1106,4 +1117,3 @@ LI_SN_LIQUID_EQ_DATA = {
     "values": [[[0, 0, 0, 0]]],
     "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN. True values should be [0.0, -28133.588, -40049.995, 0.0]"
 }
-

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -1093,3 +1093,16 @@ LI_SN_LIQUID_DATA = {
     "values": [[[0, 0]]],
     "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN"
 }
+
+LI_SN_LIQUID_EQ_DATA = {
+    "components": ["LI", "SN"],
+    "phases": ["LIQUID"],
+    "conditions": {"P": 101325, "T": 300, "X_LI": [0.0, 0.5, 1.0]},
+    "reference_states": {
+        "LI": {"phase": "LIQUID"},
+        "SN": {"phase": "LIQUID"}
+    },
+    "output": "HMR",
+    "values": [[[0, 0]]],
+    "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN"
+}

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -1097,12 +1097,13 @@ LI_SN_LIQUID_DATA = {
 LI_SN_LIQUID_EQ_DATA = {
     "components": ["LI", "SN"],
     "phases": ["LIQUID"],
-    "conditions": {"P": 101325, "T": 300, "X_LI": [0.0, 0.5, 1.0]},
+    "conditions": {"P": 101325, "T": 300, "X_LI": [0.0, 0.5, 0.8, 1.0]},
     "reference_states": {
         "LI": {"phase": "LIQUID"},
         "SN": {"phase": "LIQUID"}
     },
     "output": "HMR",
-    "values": [[[0, 0]]],
-    "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN"
+    "values": [[[0, 0, 0, 0]]],
+    "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN. True values should be [0.0, -28133.588, -40049.995, 0.0]"
 }
+

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -189,6 +189,20 @@ CU_MG_EXP_ACTIVITY = yaml.load("""{
 """, Loader=YAML_LOADER)
 
 
+CU_MG_EQ_HMR_LIQUID = {
+    "components": ["CU", "MG"],
+    "phases": ["LIQUID"],
+    "conditions": {"P": 101325, "T": [1400], "X_MG": [0.5]},
+    "reference_states": {
+        "CU": {"phase": "LIQUID"},
+        "MG": {"phase": "LIQUID"}
+    },
+    "output": "HMR",
+    "values": [[[0]]],
+    "reference": "equilibrium thermochemical tests", "comment": "True values depend on parameters."
+}
+
+
 CU_MG_HM_MIX_T_CUMG2 = yaml.load("""{
   "components": ["CU", "MG", "VA"],
   "phases": ["CUMG2"],
@@ -1115,5 +1129,5 @@ LI_SN_LIQUID_EQ_DATA = {
     },
     "output": "HMR",
     "values": [[[0, 0, 0, 0]]],
-    "reference": "non-equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN. True values should be [0.0, -28133.588, -40049.995, 0.0]"
+    "reference": "equilibrium thermochemical tests", "comment": "Valid speices: LI, LI4SN, SN; No interaction for LI/LI4SN, but there is one for LI4SN/SN. True values should be [0.0, -28133.588, -40049.995, 0.0]"
 }


### PR DESCRIPTION
This PR adds support 

Outstanding TODO:

* [x] Support data weights
* [x] Handle equilibrium failures
* [x] Drop cyipopt pin when `cyipopt=0.1.9=*_1003` is released (`conda search -c conda-forge 'cyipopt>=0.1.9=*_1003'`)

WONTFIX for this PR:

* There is no support for per-phase properties. All properties must have coordinates of only N, P, T, X(i).