### PR TITLE
Fix bug which results from inability to cast (n,1) matrix to a numpy …

### DIFF
--- a/espei/paramselect.py
+++ b/espei/paramselect.py
@@ -73,7 +73,8 @@ def _build_feature_matrix(prop, features, desired_data):
     transformed_features = sympy.Matrix([feature_transforms[prop](i) for i in features])
     all_samples = get_samples(desired_data)
     feature_matrix = np.empty((len(all_samples), len(transformed_features)), dtype=np.float)
-    feature_matrix[:, :] = [transformed_features.subs({v.T: temp, 'YS': compf[0], 'Z': compf[1]}).evalf() for temp, compf in all_samples]
+    feature_matrix[:, :] = [np.array(transformed_features.subs({v.T: temp, 'YS': compf[0], 'Z': compf[1]}).evalf()).astype(np.float64)[:,0] \
+                            for temp, compf in all_samples]
     return feature_matrix
 
 


### PR DESCRIPTION
…vector. I'm not sure whether this is due to installing with the wrong version of some package, but I reinstalled the newest version of ESPEI using the instructions on the website and had this error when testing the CU-MG example. This fix, of casting to a numpy array and manually selecting the first row seems to have fixed the problem.