### PR TITLE
Override distributed work-stealing to False in code at runtime

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,10 +11,6 @@ Installing ESPEI from PyPI (by ``pip install espei``) is **not** supported. Plea
 
     conda install -c pycalphad -c conda-forge --yes espei
 
-After installation, you must turn off dask's work stealing.
-Change the work stealing setting to ``distributed.scheduler.work-stealing: False`` in dask's configuration.
-See configuration_ below for more details.
-
 
 Development versions
 --------------------
@@ -36,31 +32,3 @@ version of ESPEI and replace it with the latest version from GitHub:
     pip install --no-deps -e .
 
 Upgrading ESPEI later requires you to run ``git pull`` in this directory.
-
-After installation, you must turn off dask's work stealing.
-Change the work stealing setting to ``distributed.scheduler.work-stealing: False`` in dask's configuration.
-See configuration_ below for more details.
-
-
-.. _configuration:
-
-Configuration
--------------
-
-ESPEI uses dask-distributed to parallelize ESPEI.
-
-After installation, you must turn off dask's work stealing!
-Change the your dask configuration file to look something like:
-
-
-.. code-block:: YAML
-
-   distributed:
-     version: 2
-     scheduler:
-       work-stealing: False
-
-
-The configuration file paths can be found by running ``from espei.utils import get_dask_config_paths; get_dask_config_paths()`` in a Python interpreter.
-If multiple configurations are found, the latter configurations take precendence over the former, so check them from last to first.
-See the `dask-distributed documentation <https://distributed.readthedocs.io/en/latest/configuration.html>`_ for more.

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -62,20 +62,6 @@ def log_version_info():
     logging.debug('emcee version       ' + str(emcee.__version__))
     logging.info("If you use ESPEI for work presented in a publication, we ask that you cite the following paper:\n    {}".format(espei.__citation__))
 
-def get_dask_config_paths():
-    candidates = dask.config.paths
-    file_paths = []
-    for path in candidates:
-        if os.path.exists(path):
-            if os.path.isdir(path):
-                file_paths.extend(sorted([
-                    os.path.join(path, p)
-                    for p in os.listdir(path)
-                    if os.path.splitext(p)[1].lower() in ('.json', '.yaml', '.yml')
-                ]))
-            else:
-                file_paths.append(path)
-    return file_paths
 
 def _raise_dask_work_stealing():
     """

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -31,7 +31,8 @@ from espei.datasets import DatasetError, load_datasets, recursive_glob, apply_ta
 from espei.optimizers.opt_mcmc import EmceeOptimizer
 
 TRACE = 15  # TRACE logging level
-
+# Force distributed's work-stealing to be False
+dask.config.set({'distributed.scheduler.work-stealing': False})
 
 parser = argparse.ArgumentParser(description=__doc__)
 

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -447,12 +447,6 @@ def get_dask_config_paths():
     -------
     list
 
-    Examples
-    --------
-    >>> config_files = get_dask_config_paths()
-    >>> len(config_files) >= 1
-    True
-
     """
     candidates = dask.config.paths
     file_paths = []


### PR DESCRIPTION
Having users turn off work-stealing in dask/distributed configuration files after setup was a nuisance. 

Now with https://github.com/dask/dask/pull/6647, dask no longer writes out commented out configuration files by default and work stealing is even more difficult for users to toggle off permanently in the filesystem. 

This PR turns off work-stealing in code on import of `espei_script.py` so users do not have to do it themselves and removes the now obsolete documentation for how to change the configuration files.

This PR also removes a duplicate definition of `get_dask_config_paths`.