### PR TITLE
FIX: Improve check for dask's work-stealing

### DIFF
--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -26,7 +26,7 @@ from pycalphad import Database
 import espei
 from espei.validation import schema
 from espei import generate_parameters
-from espei.utils import ImmediateClient, get_dask_config_paths, database_symbols_to_fit
+from espei.utils import ImmediateClient, database_symbols_to_fit
 from espei.datasets import DatasetError, load_datasets, recursive_glob, apply_tags, add_ideal_exclusions
 from espei.optimizers.opt_mcmc import EmceeOptimizer
 
@@ -77,13 +77,13 @@ def _raise_dask_work_stealing():
     >>> _raise_dask_work_stealing()  # should not raise if dask is set correctly
 
     """
-    import distributed
-    has_work_stealing = distributed.config['distributed']['scheduler']['work-stealing']
+    import dask, distributed
+    has_work_stealing = dask.config.get('distributed.scheduler.work_stealing')
     if has_work_stealing:
-        raise ValueError("The parameter 'work-stealing' is on in dask. Enabling this parameter causes some instability. "
-            "Set 'distributed.scheduler.work-stealing: False' in your dask configuration. "
-            "Configuration files on this machine are:\n{} (latter files have priority).\n"
-            "See the example at http://espei.org/en/latest/installation.html#configuration for more.".format(get_dask_config_paths()))
+        raise ValueError("The parameter 'distributed.scheduler.work-stealing' is on in dask. "
+                         "This parameter causes some instability for long-running processes. "
+                         "As of ESPEI v0.7.9, 'work-stealing' should be disabled automatically. "
+                         "If you are seeing this error, please contact a developer.")
 
 
 def get_run_settings(input_dict):

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -72,6 +72,10 @@ def _raise_dask_work_stealing():
     -------
     ValueError
 
+    Examples
+    --------
+    >>> _raise_dask_work_stealing()  # should not raise if dask is set correctly
+
     """
     import distributed
     has_work_stealing = distributed.config['distributed']['scheduler']['work-stealing']

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -435,29 +435,3 @@ def popget(d, key, default=None):
         return d.pop(key)
     except KeyError:
         return default
-
-
-def get_dask_config_paths():
-    """
-    Return a list of configuration file paths for dask.
-
-    The last path in the list has the highest precedence.
-
-    Returns
-    -------
-    list
-
-    """
-    candidates = dask.config.paths
-    file_paths = []
-    for path in candidates:
-        if os.path.exists(path):
-            if os.path.isdir(path):
-                file_paths.extend(sorted([
-                    os.path.join(path, p)
-                    for p in os.listdir(path)
-                    if os.path.splitext(p)[1].lower() in ('.json', '.yaml', '.yml')
-                ]))
-            else:
-                file_paths.append(path)
-    return file_paths


### PR DESCRIPTION
dask/distributed configuration files can separate words with hyphens or underscores, e.g. `dask.config['distributed']['scheduler']['work-stealing']` and `dask.config['distributed']['scheduler']['work_stealing']` are both possibly valid. The correct API to check for `work_stealing`/`work-stealing` is `dask.config.get('distributed.scheduler.work-stealing')` where the `get` function will find the correct `-`/`_` as necessary. 