### PR TITLE
MAINT: Fix numpy v1.20 deprecations.

### DIFF
--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -54,12 +54,12 @@ def get_data(comps, phase_name, configuration, symmetry, datasets, prop):
                                      for sblconf in data['solver']['sublattice_configurations']])
         matching_configs = np.arange(len(data['solver']['sublattice_configurations']))[matching_configs]
         # Rewrite output values with filtered data
-        desired_data[idx]['values'] = np.array(data['values'], dtype=np.float)[..., matching_configs]
+        desired_data[idx]['values'] = np.array(data['values'], dtype=np.float_)[..., matching_configs]
         desired_data[idx]['solver']['sublattice_configurations'] = recursive_tuplify(np.array(data['solver']['sublattice_configurations'],
-                                                                                              dtype=np.object)[matching_configs].tolist())
+                                                                                              dtype=np.object_)[matching_configs].tolist())
         try:
             desired_data[idx]['solver']['sublattice_occupancies'] = np.array(data['solver']['sublattice_occupancies'],
-                                                                             dtype=np.object)[matching_configs].tolist()
+                                                                             dtype=np.object_)[matching_configs].tolist()
         except KeyError:
             pass
         # Filter out temperatures below 298.15 K (for now, until better refstates exist)
@@ -95,7 +95,7 @@ def get_samples(desired_data):
     all_samples = []
     for data in desired_data:
         temperatures = np.atleast_1d(data['conditions']['T'])
-        num_configs = np.array(data['solver'].get('sublattice_configurations'), dtype=np.object).shape[0]
+        num_configs = np.array(data['solver'].get('sublattice_configurations'), dtype=np.object_).shape[0]
         site_fractions = data['solver'].get('sublattice_occupancies', [[1]] * num_configs)
         site_fraction_product = calc_site_fraction_product(site_fractions)
         # TODO: Subtle sorting bug here, if the interactions aren't already in sorted order...

--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -153,7 +153,7 @@ def check_dataset(dataset):
                 if len(component_list) != len(mole_fraction_list):
                     raise DatasetError('The length of the components list and mole fractions list in tieline {} for the ZPF point {} should be the same.'.format(tieline, zpf))
                 # check that all mole fractions are less than one
-                mf_sum = np.nansum(np.array(mole_fraction_list, dtype=np.float))
+                mf_sum = np.nansum(np.array(mole_fraction_list, dtype=np.float_))
                 if any([mf is not None for mf in mole_fraction_list]) and mf_sum > 1.0:
                     raise DatasetError('Mole fractions for tieline {} for the ZPF point {} sum to greater than one.'.format(tieline, zpf))
 

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -199,8 +199,8 @@ def calc_prop_differences(eqpropdata: EqPropData,
     update_phase_record_parameters(phase_records, parameters)
     params_dict = OrderedDict(zip(map(str, eqpropdata.params_keys), parameters))
     output = eqpropdata.output
-    weights = np.array(eqpropdata.weight, dtype=np.float)
-    samples = np.array(eqpropdata.samples, dtype=np.float)
+    weights = np.array(eqpropdata.weight, dtype=np.float_)
+    samples = np.array(eqpropdata.samples, dtype=np.float_)
 
     calculated_data = []
     for comp_conds in eqpropdata.composition_conds:
@@ -218,7 +218,7 @@ def calc_prop_differences(eqpropdata: EqPropData,
         vals = getattr(propdata, output).flatten().tolist()
         calculated_data.extend(vals)
 
-    calculated_data = np.array(calculated_data, dtype=np.float)
+    calculated_data = np.array(calculated_data, dtype=np.float_)
 
     assert calculated_data.shape == samples.shape, f"Calculated data shape {calculated_data.shape} does not match samples shape {samples.shape}"
     assert calculated_data.shape == weights.shape, f"Calculated data shape {calculated_data.shape} does not match weights shape {weights.shape}"

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -196,7 +196,7 @@ def estimate_hyperplane(phase_region: PhaseRegion, parameters: np.ndarray, appro
                 target_hyperplane_chempots.append(np.full_like(MU_values, np.nan))
             else:
                 target_hyperplane_chempots.append(MU_values)
-    target_hyperplane_mean_chempots = np.nanmean(target_hyperplane_chempots, axis=0, dtype=np.float)
+    target_hyperplane_mean_chempots = np.nanmean(target_hyperplane_chempots, axis=0, dtype=np.float_)
     return target_hyperplane_mean_chempots
 
 
@@ -233,14 +233,14 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         # Compute residual driving force
         # TODO: Check that it actually makes sense to declare this phase 'disordered'
         num_dof = sum([len(set(c).intersection(species)) for c in dbf.phases[current_phase].constituents])
-        desired_sitefracs = np.ones(num_dof, dtype=np.float)
+        desired_sitefracs = np.ones(num_dof, dtype=np.float_)
         dof_idx = 0
         for c in dbf.phases[current_phase].constituents:
             dof = sorted(set(c).intersection(comps))
             if (len(dof) == 1) and (dof[0] == 'VA'):
                 return 0
             # If it's disordered config of BCC_B2 with VA, disordered config is tiny vacancy count
-            sitefracs_to_add = np.array([cond_dict.get(v.X(d)) for d in dof], dtype=np.float)
+            sitefracs_to_add = np.array([cond_dict.get(v.X(d)) for d in dof], dtype=np.float_)
             # Fix composition of dependent component
             sitefracs_to_add[np.isnan(sitefracs_to_add)] = 1 - np.nansum(sitefracs_to_add)
             desired_sitefracs[dof_idx:dof_idx + len(dof)] = sitefracs_to_add

--- a/espei/parameter_selection/selection.py
+++ b/espei/parameter_selection/selection.py
@@ -76,7 +76,7 @@ def score_model(feature_matrix, data_quantities, model_coefficients, feature_lis
     """
     factor = aicc_factor if aicc_factor is not None else 1.0
     num_params = len(feature_list)
-    rss = np.square(np.dot(feature_matrix, model_coefficients) - data_quantities.astype(np.float)*np.array(weights)).sum()
+    rss = np.square(np.dot(feature_matrix, model_coefficients) - data_quantities.astype(np.float_)*np.array(weights)).sum()
     if np.abs(rss) < rss_numerical_limit:
         rss = rss_numerical_limit
     # Compute the corrected Akaike Information Criterion

--- a/espei/parameter_selection/ternary_parameters.py
+++ b/espei/parameter_selection/ternary_parameters.py
@@ -30,6 +30,6 @@ def build_ternary_feature_matrix(prop, candidate_models, desired_data):
     """
     transformed_features = [feature_transforms[prop](i) for i in candidate_models]
     all_samples = get_samples(desired_data)
-    feature_matrix = np.empty((len(all_samples), len(transformed_features)), dtype=np.float)
+    feature_matrix = np.empty((len(all_samples), len(transformed_features)), dtype=np.float_)
     feature_matrix[:, :] = [[trans_feat.subs({v.T: temp, 'YS': ys, 'V_I': v_i, 'V_J': v_j, 'V_K': v_k}).evalf() for trans_feat in transformed_features] for temp, (ys, (v_i, v_j, v_k)) in all_samples]
     return feature_matrix

--- a/espei/parameter_selection/utils.py
+++ b/espei/parameter_selection/utils.py
@@ -56,7 +56,7 @@ def shift_reference_state(desired_data, feature_transform, fixed_model, mole_ato
     """
     total_response = []
     for dataset in desired_data:
-        values = np.asarray(dataset['values'], dtype=np.object)*mole_atoms_per_mole_formula_unit
+        values = np.asarray(dataset['values'], dtype=np.object_)*mole_atoms_per_mole_formula_unit
         for config_idx in range(len(dataset['solver']['sublattice_configurations'])):
             occupancy = dataset['solver'].get('sublattice_occupancies', None)
             if dataset['output'].endswith('_FORM'):
@@ -115,7 +115,7 @@ def get_data_quantities(desired_property, fixed_model, fixed_portions, data):
     site_fractions = []
     for ds in data:
         for _ in ds['conditions']['T']:
-            sf = build_sitefractions(phase_name, ds['solver']['sublattice_configurations'], ds['solver'].get('sublattice_occupancies', np.ones((len(ds['solver']['sublattice_configurations']), len(ds['solver']['sublattice_configurations'][0])), dtype=np.float)))
+            sf = build_sitefractions(phase_name, ds['solver']['sublattice_configurations'], ds['solver'].get('sublattice_occupancies', np.ones((len(ds['solver']['sublattice_configurations']), len(ds['solver']['sublattice_configurations'][0])), dtype=np.float_)))
             site_fractions.append(sf)
     site_fractions = list(itertools.chain(*site_fractions))
 
@@ -138,5 +138,5 @@ def get_data_quantities(desired_property, fixed_model, fixed_portions, data):
             sf.update({YS: sf_product, Z: inter_product})
     data_qtys = [sympy.S(i).xreplace(sf).xreplace({v.T: ixx[0]}).evalf()
                  for i, sf, ixx in zip(data_qtys, site_fractions, samples)]
-    data_qtys = np.asarray(data_qtys, dtype=np.float)
+    data_qtys = np.asarray(data_qtys, dtype=np.float_)
     return data_qtys

--- a/espei/paramselect.py
+++ b/espei/paramselect.py
@@ -72,7 +72,7 @@ def _build_feature_matrix(prop, features, desired_data):
     """
     transformed_features = [feature_transforms[prop](i) for i in features]
     all_samples = get_samples(desired_data)
-    feature_matrix = np.empty((len(all_samples), len(transformed_features)), dtype=np.float)
+    feature_matrix = np.empty((len(all_samples), len(transformed_features)), dtype=np.float_)
     feature_matrix[:, :] = [[trans_feat.subs({v.T: temp, 'YS': compf[0], 'Z': compf[1]}).evalf() for trans_feat in transformed_features] for temp, compf in all_samples]
     return feature_matrix
 
@@ -177,7 +177,7 @@ def fit_formation_energy(dbf, comps, phase_name, configuration, symmetry, datase
             selected_features, selected_values = selected_model
             parameters.update(zip(*(selected_features, selected_values)))
             # Add these parameters to be fixed for the next fitting step
-            fixed_portion = np.array(selected_features, dtype=np.object)
+            fixed_portion = np.array(selected_features, dtype=np.object_)
             fixed_portion = np.dot(fixed_portion, selected_values)
             fixed_portions.append(fixed_portion)
     return parameters
@@ -243,7 +243,7 @@ def fit_ternary_interactions(dbf, phase_name, symmetry, endmembers, datasets, ri
             logging.log(TRACE, 'INTERACTION: {}'.format(ixx))
         parameters = fit_formation_energy(dbf, sorted(dbf.elements), phase_name, ixx, symmetry, datasets, ridge_alpha, aicc_phase_penalty=aicc_phase_penalty)
         # Organize parameters by polynomial degree
-        degree_polys = np.zeros(3, dtype=np.object)
+        degree_polys = np.zeros(3, dtype=np.object_)
         YS = sympy.Symbol('YS')
         # asymmetric parameters should have Mugiannu V_I/V_J/V_K, while symmetric just has YS
         is_asymmetric = any([(k.has(sympy.Symbol('V_I'))) and (v != 0) for k, v in parameters.items()])
@@ -402,7 +402,7 @@ def phase_fit(dbf, phase_name, symmetry, subl_model, site_ratios, datasets, refd
             logging.log(TRACE, 'INTERACTION: {}'.format(ixx))
         parameters = fit_formation_energy(dbf, sorted(dbf.elements), phase_name, ixx, symmetry, datasets, ridge_alpha, aicc_phase_penalty=aicc_phase_penalty)
         # Organize parameters by polynomial degree
-        degree_polys = np.zeros(10, dtype=np.object)
+        degree_polys = np.zeros(10, dtype=np.object_)
         for degree in reversed(range(10)):
             check_symbol = sympy.Symbol('YS') * sympy.Symbol('Z')**degree
             keys_to_remove = []

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -478,7 +478,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
     matplotlib.Axes
 
     """
-    all_samples = np.array(get_samples(desired_data), dtype=np.object)
+    all_samples = np.array(get_samples(desired_data), dtype=np.object_)
     endpoints = endmembers_from_interaction(configuration)
     interacting_subls = [c for c in recursive_tuplify(configuration) if isinstance(c, tuple)]
     disordered_config = False
@@ -500,7 +500,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
         yattr = y
     if len(endpoints) == 1:
         # This is an endmember so we can just compute T-dependent stuff
-        temperatures = np.array([i[0] for i in all_samples], dtype=np.float)
+        temperatures = np.array([i[0] for i in all_samples], dtype=np.float_)
         if temperatures.min() != temperatures.max():
             temperatures = np.linspace(temperatures.min(), temperatures.max(), num=100)
         else:
@@ -561,9 +561,9 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
 
     for data in desired_data:
         indep_var_data = None
-        response_data = np.zeros_like(data['values'], dtype=np.float)
+        response_data = np.zeros_like(data['values'], dtype=np.float_)
         if x == 'T' or x == 'P':
-            indep_var_data = np.array(data['conditions'][x], dtype=np.float).flatten()
+            indep_var_data = np.array(data['conditions'][x], dtype=np.float_).flatten()
         elif x == 'Z':
             if disordered_config:
                 # Take the second element of the first interacting sublattice as the coordinate
@@ -577,7 +577,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
                     subl_idx = int(subl_idx)
                 indep_var_data = [c[subl_idx][1] for c in occ]
             else:
-                interactions = np.array([i[1][1] for i in get_samples([data])], dtype=np.float)
+                interactions = np.array([i[1][1] for i in get_samples([data])], dtype=np.float_)
                 indep_var_data = 1 - (interactions+1)/2
             if y.endswith('_MIX') and data['output'].endswith('_FORM'):
                 # All the _FORM data we have still has the lattice stability contribution
@@ -595,7 +595,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
                     points[point_idx].update({key: 0 for key in missing_variables})
                     # Change entry to a sorted array of site fractions
                     points[point_idx] = list(OrderedDict(sorted(points[point_idx].items(), key=str)).values())
-                points = np.array(points, dtype=np.float)
+                points = np.array(points, dtype=np.float_)
                 # TODO: Real temperature support
                 points = points[None, None]
                 stability = calculate(dbf, comps, [phase_name], output=data['output'][:-5],
@@ -603,7 +603,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
                                       model=mod_latticeonly, mode='numpy')
                 response_data -= stability[data['output'][:-5]].values.squeeze()
 
-        response_data += np.array(data['values'], dtype=np.float)
+        response_data += np.array(data['values'], dtype=np.float_)
         response_data = response_data.flatten()
         if not bar_chart:
             extra_kwargs = {}

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -96,7 +96,7 @@ def generate_symmetric_group(configuration, symmetry):
 
     """
     configurations = [recursive_tuplify(configuration)]
-    permutation = np.array(symmetry, dtype=np.object)
+    permutation = np.array(symmetry, dtype=np.object_)
 
     def permute(x):
         if len(x) == 0:
@@ -106,8 +106,8 @@ def generate_symmetric_group(configuration, symmetry):
         return x
 
     if symmetry is not None:
-        while np.any(np.array(symmetry, dtype=np.object) != permute(permutation)):
-            new_conf = np.array(configurations[0], dtype=np.object)
+        while np.any(np.array(symmetry, dtype=np.object_) != permute(permutation)):
+            new_conf = np.array(configurations[0], dtype=np.object_)
             subgroups = []
             # There is probably a more efficient way to do this
             for subl in permutation:

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -66,7 +66,7 @@ class ImmediateClient(Client):
 def sigfigs(x, n):
     """Round x to n significant digits"""
     if x != 0:
-        return np.around(x, -(np.floor(np.log10(np.abs(x)))).astype(np.int) + (n - 1))
+        return np.around(x, -(np.floor(np.log10(np.abs(x)))).astype(np.int_) + (n - 1))
     else:
         return x
 

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -377,5 +377,5 @@ def test_equilibrium_thermochemical_error_computes_correct_probability(datasets_
     errors, weights = calc_prop_differences(eqdata[0], np.array([-31626.6]))
     assert np.all(np.isclose(errors, [-31626.6*0.5*0.5]))
     # change to -40000
-    errors, weights = calc_prop_differences(eqdata[0], np.array([-40000], np.float))
+    errors, weights = calc_prop_differences(eqdata[0], np.array([-40000], np.float_))
     assert np.all(np.isclose(errors, [-40000*0.5*0.5]))

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -138,6 +138,6 @@ def test_equilibrium_thermochemical_correct_probability(datasets_db):
     assert np.isclose(prob, expected_prob)
 
     # change to -40000
-    prob = opt.predict(np.array([-40000], dtype=np.float), **ctx)
+    prob = opt.predict(np.array([-40000], dtype=np.float_), **ctx)
     expected_prob = norm(loc=0, scale=500).logpdf([-40000*0.5*0.5]).sum()
     assert np.isclose(prob, expected_prob)


### PR DESCRIPTION
The changes are backwards compatible to before numpy v1.13 (pycalphad's minimum).
See https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated for more details.