### PR TITLE
ENH: Allow for disabling datasets using JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .smt/
 __pycache__
 build
+_build
 .cache
 dask-worker-space
 

--- a/espei/database_utils.py
+++ b/espei/database_utils.py
@@ -92,10 +92,12 @@ def initialize_database(phase_models, ref_state, dbf=None, fallback_ref_state="S
 
     # Add the phases
     for phase_name, phase_data in phase_models['phases'].items():
-        # TODO: Need to support model hints for: magnetic, order-disorder, etc.
-        site_ratios = phase_data['sublattice_site_ratios']
-        subl_model = phase_data['sublattice_model']
         if phase_name not in dbf.phases.keys():  # Do not clobber user phases
+            # TODO: Need to support model hints for: magnetic, order-disorder, etc.
+            site_ratios = phase_data['sublattice_site_ratios']
+            subl_model = phase_data['sublattice_model']
+            # Only generate the sublattice model for active components
+            subl_model = [sorted(set(subl).intersection(dbf.elements)) for subl in subl_model]
             dbf.add_phase(phase_name, dict(), site_ratios)
             dbf.add_phase_constituents(phase_name, subl_model)
     

--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -314,7 +314,7 @@ def add_ideal_exclusions(datasets):
     return datasets
 
 
-def load_datasets(dataset_filenames):
+def load_datasets(dataset_filenames, include_disabled=False):
     """
     Create a PickelableTinyDB with the data from a list of filenames.
 
@@ -332,6 +332,9 @@ def load_datasets(dataset_filenames):
         with open(fname) as file_:
             try:
                 d = json.load(file_)
+                if not include_disabled and d.get('disabled', False):
+                    # The dataset is disabled and not included
+                    continue
                 check_dataset(d)
                 ds_database.insert(clean_dataset(d))
             except ValueError as e:

--- a/tests/test_parameter_generation.py
+++ b/tests/test_parameter_generation.py
@@ -459,3 +459,19 @@ def test_model_contributions_can_be_excluded_mixed_datasets(datasets_db):
     dbf = generate_parameters(CR_FE_PHASE_MODELS, datasets_db, 'SGTE91', 'linear', dbf=Database(CR_FE_INITIAL_TDB_CONTRIBUTIONS))
     assert dbf.symbols['VV0000'] == 40000  # 4 mol-atom/mol-form * 10000 J/mol-atom, verified with no initial Database
 
+def test_parameters_can_be_generated_with_component_subsets(datasets_db):
+    CR_FE_PHASE_MODELS = {
+        "components": ["CR", "FE"],
+        "phases": {
+               "BCC_A2": {
+                  "sublattice_model": [["CR", "FE", "NI", "V"]],
+                  "sublattice_site_ratios": [1]
+               },
+               "INACTIVE": {
+                    "sublattice_model": [["NI", "V"]],
+                    "sublattice_site_ratios": [1]
+               }
+          }
+      }
+
+    generate_parameters(CR_FE_PHASE_MODELS, datasets_db, 'SGTE91', 'linear')


### PR DESCRIPTION
Previously we used to recommend that datasets be disabled by either moving them out of the path or by changing their file extension from `.json` to something else, like `.json.disabled`. 

This PR aims to enable datasets to be disabled by using the `disabled: False` in the top level of JSON datasets, which allows for cleaner and more programmatic access.