### PR TITLE
MAINT/TST: Add pytest configuration

### DIFF
--- a/.github/workflows/test_espei.yaml
+++ b/.github/workflows/test_espei.yaml
@@ -75,4 +75,4 @@ jobs:
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - name: Test with pytest
       shell: bash -l {0}
-      run: pytest -v --doctest-modules espei tests
+      run: pytest -v

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,7 +35,7 @@ ESPEI uses `pytest <https://pytest.org>`_ as a test runner. The tests can be run
 
 .. code-block:: bash
 
-   pytest -v --doctest-modules espei tests
+   pytest
 
 
 Style

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,8 @@ versionfile_source = espei/_version.py
 versionfile_build = espei/_version.py
 tag_prefix = ''
 parentdir_prefix = espei-
+[tool:pytest]
+addopts = --doctest-modules
+testpaths =
+    espei
+    tests


### PR DESCRIPTION
This adds default test locations `espei` and `tests` and adds the `--doctest-modules` option. 

The CI tests are updated and the docs are updated to reflect this.