### PR TITLE
FIX: Fix setting GHSER__ to zero in database initialization

### DIFF
--- a/espei/database_utils.py
+++ b/espei/database_utils.py
@@ -111,5 +111,5 @@ def initialize_database(phase_models, ref_state, dbf=None, fallback_ref_state="S
             # Using this ensures that GHSER functions will be unique, e.g.
             # GHSERC would be an abbreviation for GHSERCA.
             sym_name = "GHSER" + (element.upper()*2)[:2]
-            dbf.symbols.setdefault(sym_name, 0)
+            dbf.symbols.setdefault(sym_name, ser_stability[element])
     return dbf

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -97,3 +97,23 @@ def test_database_initialization_custom_refstate():
     delattr(espei.refdata, CUSTOM_REFDATA_NAME + "Stable")
     delattr(espei.refdata, CUSTOM_REFDATA_NAME)
     delattr(espei.refdata, CUSTOM_REFDATA_NAME + "SER")
+
+
+def test_database_initialization_adds_GHSER_data():
+    phase_models = {
+        "components": ["CR", "NI"],
+        "phases": {
+            "FCC_A1": {
+                "sublattice_model": [["CR", "NI"]],
+                "sublattice_site_ratios": [1],
+            },
+            "BCC": {
+                "aliases": ["BCC_A2"],
+                "sublattice_model": [["CR", "NI"]],
+                "sublattice_site_ratios": [1.0],
+            },
+        }
+    }
+    dbf = initialize_database(phase_models, "SGTE91")
+    assert dbf.symbols["GHSERCR"] != sympy.S.Zero
+    assert dbf.symbols["GHSERNI"] != sympy.S.Zero


### PR DESCRIPTION
Fixes a bug introduced by #158 where GHSER data was set to zero. Includes a test.