### PR TITLE
MAINT: Remove automatically adding ideal exclusions

### DIFF
--- a/espei/datasets.py
+++ b/espei/datasets.py
@@ -282,38 +282,6 @@ def apply_tags(datasets, tags):
                 datasets.update(match, doc_ids=[match.doc_id])
 
 
-def add_ideal_exclusions(datasets):
-    """
-    If there are single phase datasets present and none of them have an
-    `excluded_model_contributions` key, add ideal exclusions automatically and
-    emit a DeprecationWarning that this feature will be going away.
-
-    Parameters
-    ----------
-    datasets : PickleableTinyDB
-
-    Returns
-    -------
-    PickleableTinyDB
-
-    """
-    all_single_phase = datasets.search(where('solver').exists())
-    no_exclusions = datasets.search(where('solver').exists() & (~where('excluded_model_contributions').exists()))
-    if len(all_single_phase) > 0 and len(all_single_phase) == len(no_exclusions):
-        idmix_warning = "Single phase datasets are present, but there are no specified `excluded_model_contributions` keys present. " + \
-                        "'idmix' exclusion will be added automatically for backwards compatibility, but this will go away in ESPEI v0.8. " + \
-                        "If you want ideal mixing contributions to be excluded, see the documentation for building datasets: http://espei.org/en/latest/input_data.html"
-        warnings.warn(idmix_warning, DeprecationWarning)
-        print(idmix_warning)
-        import espei
-        if int(espei.__version__.split('.')[1]) >= 8 or int(espei.__version__.split('.')[0]) > 0:
-            raise ValueError("ESPEI developer: remove the automatic addition of ideal mixing exclusions")
-        for ds in all_single_phase:
-            ds['excluded_model_contributions'] = ['idmix']
-            datasets.update(ds, doc_ids=[ds.doc_id])
-    return datasets
-
-
 def load_datasets(dataset_filenames, include_disabled=False):
     """
     Create a PickelableTinyDB with the data from a list of filenames.

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -120,7 +120,7 @@ def get_run_settings(input_dict):
         if run_settings['mcmc']['scheduler'] == 'None':
             warnings.warn(
                 "Setting scheduler to the string 'None' will be deprecated in ESPEI "
-                "0.9. Use `null` in YAML or `None` in Python.", DeprecationWarning
+                "0.9. Use `null` in YAML or `None` in Python.", FutureWarning
             )
             run_settings['mcmc']['scheduler'] = None
     if not schema.validate(run_settings):

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -29,7 +29,7 @@ import espei
 from espei.validation import schema
 from espei import generate_parameters
 from espei.utils import ImmediateClient, database_symbols_to_fit
-from espei.datasets import DatasetError, load_datasets, recursive_glob, apply_tags, add_ideal_exclusions
+from espei.datasets import DatasetError, load_datasets, recursive_glob, apply_tags
 from espei.optimizers.opt_mcmc import EmceeOptimizer
 
 _log = logging.getLogger(__name__)
@@ -158,7 +158,6 @@ def run_espei(run_settings):
     dataset_path = system_settings['datasets']
     datasets = load_datasets(sorted(recursive_glob(dataset_path, '*.json')))
     apply_tags(datasets, system_settings.get('tags', dict()))
-    add_ideal_exclusions(datasets)
     removed_ids = datasets.remove(where('disabled') == True)
     if len(removed_ids) > 0:
         _log.debug('Removed %d disabled datasets', len(removed_ids))

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -120,7 +120,7 @@ def get_run_settings(input_dict):
         if run_settings['mcmc']['scheduler'] == 'None':
             warnings.warn(
                 "Setting scheduler to the string 'None' will be deprecated in ESPEI "
-                "0.9. Use `null` in YAML or `None` in Python.", FutureWarning
+                "0.9. Use `null` in YAML or `None` in Python.", DeprecationWarning
             )
             run_settings['mcmc']['scheduler'] = None
     if not schema.validate(run_settings):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from espei.datasets import DatasetError, check_dataset, clean_dataset, apply_tags, add_ideal_exclusions
+from espei.datasets import DatasetError, check_dataset, clean_dataset, apply_tags
 
 from .testing_data import CU_MG_EXP_ACTIVITY, CU_MG_DATASET_THERMOCHEMICAL_STRING_VALUES, CU_MG_DATASET_ZPF_STRING_VALUES, LI_SN_LIQUID_DATA
 from .fixtures import datasets_db
@@ -470,20 +470,3 @@ def test_applying_tags(datasets_db):
     assert len(datasets_db.all()) == 1
     assert "newkey_from_tag" in datasets_db.all()[0]
     assert datasets_db.all()[0]["newkey_from_tag"] == ["tag", "values"]
-
-
-def test_adding_ideal_exclustions(datasets_db):
-    """Test that adding ideal exclusions to single phase datasets works"""
-    datasets_db.insert(dataset_single_valid)
-    datasets_db.insert(dataset_multi_valid_ternary)
-    assert len(datasets_db.all()) == 2
-    for ds in datasets_db.all():
-        assert "excluded_model_contributions" not in ds
-    add_ideal_exclusions(datasets_db)
-    assert len(datasets_db.all()) == 2
-    num_with_excluded_mod_contributions = 0
-    for ds in datasets_db.all():
-        if "excluded_model_contributions" in ds:
-            num_with_excluded_mod_contributions += 1
-            assert ds["excluded_model_contributions"] == ["idmix"]
-    assert num_with_excluded_mod_contributions == 1


### PR DESCRIPTION
The `add_ideal_exclusions` function was added by #102 in June 2019 and was also deprecated at that time for removal in ESPEI 0.8. This function and its usages are now removed in favor of manually adding the exclusions or using tags.