### PR TITLE
FIX: parameter selection: use set of excluded model contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ What's New
 Development: |version|
 ======================
 
+Improvements
+------------
+* Fix a bug where excluded model contributions could be double counted (`@bocklund`_ - :issue:`181`)
+
 0.8.2 (2021-05-05)
 ==================
 

--- a/espei/parameter_selection/utils.py
+++ b/espei/parameter_selection/utils.py
@@ -59,6 +59,7 @@ def shift_reference_state(desired_data, feature_transform, fixed_model, mole_ato
     total_response = []
     for dataset in desired_data:
         values = np.asarray(dataset['values'], dtype=np.object_)*mole_atoms_per_mole_formula_unit
+        unique_excluded_contributions = set(dataset.get('excluded_model_contributions', []))
         for config_idx in range(len(dataset['solver']['sublattice_configurations'])):
             occupancy = dataset['solver'].get('sublattice_occupancies', None)
             if dataset['output'].endswith('_FORM'):
@@ -70,7 +71,7 @@ def shift_reference_state(desired_data, feature_transform, fixed_model, mole_ato
                     values[..., config_idx] += feature_transform(fixed_model.models['ref'])*mole_atoms_per_mole_formula_unit
             else:
                 raise ValueError(f'Unknown property to shift: {dataset["output"]}')
-            for excluded_contrib in dataset.get('excluded_model_contributions', []):
+            for excluded_contrib in unique_excluded_contributions:
                 values[..., config_idx] += feature_transform(fixed_model.models[excluded_contrib])*mole_atoms_per_mole_formula_unit
         total_response.append(values.flatten())
     return total_response

--- a/tests/test_parameter_generation.py
+++ b/tests/test_parameter_generation.py
@@ -1,5 +1,6 @@
 """The test_parameter_generation module tests that parameter selection is correct"""
 
+import copy
 from tinydb import where
 from tinydb.storages import MemoryStorage
 import numpy as np
@@ -455,6 +456,15 @@ def test_initial_database_can_be_supplied(datasets_db):
 def test_model_contributions_can_be_excluded(datasets_db):
     """Model contributions excluded in the datasets should not be fit"""
     datasets_db.insert(CR_FE_HM_MIX_EXCLUDED_MAG)
+    dbf = generate_parameters(CR_FE_PHASE_MODELS, datasets_db, 'SGTE91', 'linear', dbf=Database(CR_FE_INITIAL_TDB_CONTRIBUTIONS))
+    assert dbf.symbols['VV0000'] == 40000  # 4 mol-atom/mol-form * 10000 J/mol-atom, verified with no initial Database
+
+
+def test_multiple_excluded_contributions(datasets_db):
+    """Model contributions excluded more than once in the datasets still produce correct results"""
+    double_exclude_dataset = copy.deepcopy(CR_FE_HM_MIX_EXCLUDED_MAG)
+    double_exclude_dataset['excluded_model_contributions'] = ['mag', 'mag']
+    datasets_db.insert(double_exclude_dataset)
     dbf = generate_parameters(CR_FE_PHASE_MODELS, datasets_db, 'SGTE91', 'linear', dbf=Database(CR_FE_INITIAL_TDB_CONTRIBUTIONS))
     assert dbf.symbols['VV0000'] == 40000  # 4 mol-atom/mol-form * 10000 J/mol-atom, verified with no initial Database
 


### PR DESCRIPTION
Using a set prevents double-counting exclusions. Includes a test.