### PR TITLE
DOC: ReadTheDocs: disable LaTeX formats and cleanup version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ dask-worker-space
 
 # Sphinx documentation
 docs/_build
-docs/conf.py
 
 # Editors
 *.sublime-project

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dask-worker-space
 
 # Sphinx documentation
 docs/_build
+docs/conf.py
 
 # Editors
 *.sublime-project

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,5 +6,6 @@ conda:
 sphinx:
    configuration: docs/conf.py
 
+# PDF/LaTeX currently broken
+# see: https://github.com/PhasesResearchLab/ESPEI/issues/167
 formats: []
-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,4 +3,5 @@ version: 2
 conda:
   environment: environment-dev.yml
 
-formats: all
+formats: []
+

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,5 +3,8 @@ version: 2
 conda:
   environment: environment-dev.yml
 
+sphinx:
+   configuration: docs/conf.py
+
 formats: []
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,6 @@ version: 2
 conda:
   environment: environment-dev.yml
 
-sphinx:
-   configuration: docs/conf.py
-
 # PDF/LaTeX currently broken
 # see: https://github.com/PhasesResearchLab/ESPEI/issues/167
 formats: []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,9 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))  # For autodoc and version loading
 from espei import __version__ as espei_version
+# Cleanup ESPEI version, since RTD dirties the repository
+if espei_version.endswith('.dirty'):
+    espei_version = espei_version[:-6]
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
* RTD config: Switch off building `all` formats, since LaTeX builds are failing (#167)
* Cleanup ESPEI development `|version|` information to remove the `.dirty` from the version since RTD dirties the version info