### PR TITLE
FIX: Refactor PhaseRegion; better stoichiometric phase support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Improvements
 ------------
 * Fix a bug where excluded model contributions could be double counted (`@bocklund`_ - :issue:`181`)
 * Support internal API changes for pycalphad 0.8.5 (`@bocklund`_ - :issue:`183`)
+* Fix a regression for ZPF error calculations introduced in :issue:`181` where prescribed phase compositions of stoichiometric phases that used to work no longer work because the phase composition of a stoichiometric phase may be unsatisfiable (`@bocklund`_ - :issue:`185`).
+* Fix a bug in ZPF error calculations where stoichiometric phases could give incorrect energies for exact equilibrium when prescribed mass balance conditions could not be satisfied. The fix now computes the driving force exactly in all cases for stoichiometric compounds. (`@bocklund`_ - :issue:`185`)
 
 0.8.2 (2021-05-05)
 ==================

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -184,7 +184,7 @@ def get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=None, symb
             desired_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=(where('solver').exists()))
             if len(desired_data) == 0:
                 continue
-            unique_exclusions = set([tuple(sorted(d.get('excluded_model_contributions', []))) for d in desired_data])
+            unique_exclusions = set([tuple(sorted(set(d.get('excluded_model_contributions', [])))) for d in desired_data])
             for exclusion in unique_exclusions:
                 data_dict = {
                     'phase_name': phase_name,

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -55,6 +55,10 @@ class PhaseRegion:
     phases: Sequence[str]
     models: Dict[str, Model]
 
+    def eq_str(self):
+        phase_compositions = ', '.join(f'{vtx.phase_name}: {vtx.comp_conds}' for vtx in self.vertices)
+        return f"conds: ({self.potential_conds}), comps: ({phase_compositions})"
+
 
 def _safe_index(items, index):
     try:
@@ -440,11 +444,6 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
     return driving_force
 
 
-def _format_phase_compositions(phase_region: PhaseRegion):
-    phase_compositions = ', '.join(f'{vtx.phase_name}: {vtx.comp_conds}' for vtx in phase_region.vertices)
-    return f"conds: ({phase_region.potential_conds}), comps: ({phase_compositions})"
-
-
 def calculate_zpf_driving_forces(zpf_data: Sequence[Dict[str, Any]],
                                  parameters: ArrayLike = None,
                                  approximate_equilibrium: bool = False,
@@ -492,7 +491,7 @@ def calculate_zpf_driving_forces(zpf_data: Sequence[Dict[str, Any]],
         # for the set of phases and corresponding tie-line verticies in equilibrium
         for phase_region in data['phase_regions']:
             # 1. Calculate the average multiphase hyperplane
-            eq_str = _format_phase_compositions(phase_region)
+            eq_str = phase_region.eq_str()
             target_hyperplane = estimate_hyperplane(phase_region, parameters, approximate_equilibrium=approximate_equilibrium)
             if np.any(np.isnan(target_hyperplane)):
                 _log.debug('NaN target hyperplane. Equilibria: (%s), driving force: 0.0, reference: %s.', eq_str, dataset_ref)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -16,8 +16,9 @@ composition conditions to calculate chemical potentials at.
 
 import logging
 import warnings
+from dataclasses import dataclass
 from collections import OrderedDict
-from typing import Sequence, Dict, NamedTuple, Any, Union, List, Tuple
+from typing import Sequence, Dict, Any, Union, List, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -34,6 +35,21 @@ from espei.utils import PickleableTinyDB
 from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters
 
 _log = logging.getLogger(__name__)
+
+
+
+@dataclass
+class PhaseRegion:
+    region_phases: Sequence[str]
+    potential_conds: Dict[v.StateVariable, float]
+    comp_conds: Sequence[Dict[v.X, float]]
+    phase_points: Sequence[ArrayLike]
+    phase_flags: Sequence[str]
+    dbf: Database
+    species: Sequence[v.Species]
+    phases: Sequence[str]
+    models: Dict[str, Model]
+    phase_records: Sequence[Dict[str, PhaseRecord]]
 
 
 def _safe_index(items, index):
@@ -224,18 +240,6 @@ def extract_phases_comps(phase_region):
         phase_flags.append(flag)
     return region_phases, region_comp_conds, phase_flags
 
-
-PhaseRegion = NamedTuple('PhaseRegion', (('region_phases', Sequence[str]),
-                                         ('potential_conds', Dict[v.StateVariable, float]),
-                                         ('comp_conds', Sequence[Dict[v.X, float]]),
-                                         ('phase_points', Sequence[ArrayLike]),
-                                         ('phase_flags', Sequence[str]),
-                                         ('dbf', Database),
-                                         ('species', Sequence[v.Species]),
-                                         ('phases', Sequence[str]),
-                                         ('models', Dict[str, Model]),
-                                         ('phase_records', Sequence[Dict[str, PhaseRecord]]),
-                                         ))
 
 
 def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float]):


### PR DESCRIPTION
* Make `PhaseRegion` a dataclass
* Introduce a `RegionVertex` dataclass instead of storing the vertex data in lists of `PhaseRegion`
* Fix a regression in ZPF data introduced by #151 where prescribed phase compositions of stoichiometric phases that used to work no longer work because the phase composition of a stoichiometric phase may be unsatisfiable. Now there's a check for stoichiometric phases that will not try to solve for the points.
* Fixes a bug where stoichiometric phases used `equilibrium` in driving force calculations which could give bad energies for exact equilibrium where mass balance could not be satisfied (approximate was not affected). Now exact and approximate equilibrium use driving force estimation via `calculate` which is always exact for stoichiometric phases because they have exactly one point.