### PR TITLE
FIX: Fix endmember/interaction plot labeling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ What's New
 
 |version| (development)
 =======================
+* Fix a regression where `plot_interaction` and `plot_endmember` re-used reference labels and markers (`@bocklund`_ - :issue:`187`)
 
 0.8.3 (2021-05-08)
 ==================

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -615,9 +615,10 @@ def plot_interaction(dbf, comps, phase_name, configuration, output, datasets=Non
         dataplot_kwargs.setdefault('markersize', 8)
         dataplot_kwargs.setdefault('linestyle', 'none')
         dataplot_kwargs.setdefault('clip_on', False)
-        dataplot_kwargs.setdefault('label', symbol_map[ref]['formatted'])
-        dataplot_kwargs.setdefault('marker', symbol_map[ref]['markers']['marker'])
-        dataplot_kwargs.setdefault('fillstyle', symbol_map[ref]['markers']['fillstyle'])
+        # Cannot use setdefault because it won't overwrite previous iterations
+        dataplot_kwargs['label'] = symbol_map[ref]['formatted']
+        dataplot_kwargs['marker'] = symbol_map[ref]['markers']['marker']
+        dataplot_kwargs['fillstyle'] = symbol_map[ref]['markers']['fillstyle']
         ax.plot(indep_var_data, response_data, **dataplot_kwargs)
     ax.set_xlim((0, 1))
     ax.set_xlabel(str(':'.join(endpoints[0])) + ' to ' + str(':'.join(endpoints[1])))
@@ -715,9 +716,10 @@ def plot_endmember(dbf, comps, phase_name, configuration, output, datasets=None,
         dataplot_kwargs.setdefault('markersize', 8)
         dataplot_kwargs.setdefault('linestyle', 'none')
         dataplot_kwargs.setdefault('clip_on', False)
-        dataplot_kwargs.setdefault('label', symbol_map[ref]['formatted'])
-        dataplot_kwargs.setdefault('marker', symbol_map[ref]['markers']['marker'])
-        dataplot_kwargs.setdefault('fillstyle', symbol_map[ref]['markers']['fillstyle'])
+        # Cannot use setdefault because it won't overwrite previous iterations
+        dataplot_kwargs['label'] = symbol_map[ref]['formatted']
+        dataplot_kwargs['marker'] = symbol_map[ref]['markers']['marker']
+        dataplot_kwargs['fillstyle'] = symbol_map[ref]['markers']['fillstyle']
         ax.plot(indep_var_data, response_data, **dataplot_kwargs)
 
     ax.set_xlabel(plot_mapping.get(x, x))


### PR DESCRIPTION
Fix a regression where `plot_interaction` and `plot_endmember` re-used reference labels and markers