### PR TITLE
MAINT: Remove `get_data` from plotting/parameter selection

### DIFF
--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -1,5 +1,5 @@
 """
-Utilities for querying and modifiying datasets.
+Utilities for querying, modifiying, and extracting data from Datasets.
 """
 import copy
 from typing import List
@@ -39,7 +39,7 @@ def filter_configurations(desired_data: List[Dataset], configuration, symmetry) 
     return desired_data
 
 
-def filter_temperatures(desired_data) -> List[Dataset]:
+def filter_temperatures(desired_data: List[Dataset]) -> List[Dataset]:
     """
     Return non-equilibrium thermochemical datasets with temperatures below 298.15 K removed.
 
@@ -161,7 +161,7 @@ def ravel_zpf_values(desired_data, independent_comps, conditions=None):
 
     Parameters
     ----------
-    desired_data : espei.utils.PickleableTinyDB
+    desired_data : List[Dataset]
         The selected data
     independent_comps : list
         List of indepdendent components. Used for mass balance component conversion

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -1,42 +1,10 @@
 """
-Internal utilities for developer use. May not be useful to users.
+Utilities for querying and modifiying datasets.
 """
 import copy
 import numpy as np
 import tinydb
 from espei.sublattice_tools import canonicalize, recursive_tuplify
-
-
-def get_data(comps, phase_name, configuration, symmetry, datasets, prop):
-    """
-    Return a list of cleaned single phase datasets matching the passed arguments.
-
-    Parameters
-    ----------
-    comps : list
-        List of string component names
-    phase_name : str
-        Name of phase
-    configuration : tuple
-        Sublattice configuration as a tuple, e.g. ("CU", ("CU", "MG"))
-    symmetry : list of lists
-        List of sublattice indices with symmetry
-    datasets : espei.utils.PickleableTinyDB
-        Database of datasets to search for data
-    prop : list
-        String name of the property of interest.
-
-    Returns
-    -------
-    list
-        List of datasets matching the arguments.
-
-    """
-    solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
-    desired_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=solver_qry)
-    desired_data = filter_configurations(desired_data, configuration, symmetry)
-    desired_data = filter_temperatures(desired_data)
-    return desired_data
 
 
 def filter_configurations(desired_data, configuration, symmetry):

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -2,11 +2,9 @@
 Internal utilities for developer use. May not be useful to users.
 """
 import copy
-import itertools
 import numpy as np
 import tinydb
 from espei.sublattice_tools import canonicalize, recursive_tuplify
-from espei.parameter_selection.redlich_kister import calc_interaction_product
 
 
 def get_data(comps, phase_name, configuration, symmetry, datasets, prop):

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -332,7 +332,9 @@ def symmetry_filter(x, config, symmetry):
 
 def get_prop_data(comps, phase_name, prop, datasets, additional_query=None):
     """
-    Return datasets that match the components, phase and property
+    Return a copy of datasets that match the components, phase and property.
+
+    The queried datasets are copied to ensure that any modifications are safe.
 
     Parameters
     ----------
@@ -362,4 +364,4 @@ def get_prop_data(comps, phase_name, prop, datasets, additional_query=None):
         (tinydb.where('phases') == [phase_name]) &
         additional_query
     )
-    return desired_data
+    return copy.deepcopy(desired_data)

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -9,7 +9,7 @@ from espei.sublattice_tools import canonicalize, recursive_tuplify
 
 def get_data(comps, phase_name, configuration, symmetry, datasets, prop):
     """
-    Return list of cleaned single phase datasets matching the passed arguments.
+    Return a list of cleaned single phase datasets matching the passed arguments.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ def get_data(comps, phase_name, configuration, symmetry, datasets, prop):
 
 def filter_configurations(desired_data, configuration, symmetry):
     """
-    Return a copy of non-equilibrium thermochemical datasets with invalid configurations removed.
+    Return non-equilibrium thermochemical datasets with invalid configurations removed.
 
     Parameters
     ----------
@@ -57,34 +57,25 @@ def filter_configurations(desired_data, configuration, symmetry):
     List[Dict[str, Any]]
 
     """
-    # TODO: can this copy be removed safely?
-    # This seems to be necessary because the 'values' member does not modify 'datasets'
-    # But everything else does!
-    desired_data = copy.deepcopy(desired_data)
-
-    for idx, data in enumerate(desired_data):
+    for data in desired_data:
         # Filter output values to only contain data for matching sublattice configurations
         matching_configs = np.array([(canonicalize(sblconf, symmetry) == canonicalize(configuration, symmetry))
                                      for sblconf in data['solver']['sublattice_configurations']])
         matching_configs = np.arange(len(data['solver']['sublattice_configurations']))[matching_configs]
         # Rewrite output values with filtered data
-        desired_data[idx]['values'] = np.array(data['values'], dtype=np.float_)[..., matching_configs]
-        desired_data[idx]['solver']['sublattice_configurations'] = recursive_tuplify(np.array(data['solver']['sublattice_configurations'],
-                                                                                              dtype=np.object_)[matching_configs].tolist())
-        try:
-            desired_data[idx]['solver']['sublattice_occupancies'] = np.array(data['solver']['sublattice_occupancies'],
-                                                                             dtype=np.object_)[matching_configs].tolist()
-        except KeyError:
-            pass
+        data['values'] = np.array(data['values'], dtype=np.float_)[..., matching_configs]
+        data['solver']['sublattice_configurations'] = recursive_tuplify(np.array(data['solver']['sublattice_configurations'], dtype=np.object_)[matching_configs].tolist())
+        if 'sublattice_occupancies' in data['solver']:
+            data['solver']['sublattice_occupancies'] = np.array(data['solver']['sublattice_occupancies'], dtype=np.object_)[matching_configs].tolist()
     return desired_data
 
 
 def filter_temperatures(desired_data):
     """
-    Return a copy of non-equilibrium thermochemical datasets with temperatures below 298.15 K removed.
+    Return non-equilibrium thermochemical datasets with temperatures below 298.15 K removed.
 
     The currently provided unary reference data from ESPEI use the SGTE unary data that
-    is defined as piecewise in temperature with a lower limit of 298.15 K for most
+    are defined as piecewise in temperature with a lower limit of 298.15 K for most
     elements. Since pycalphad does not extrapolate outside of piecewise temperature
     limits, this filter prevents fitting data to regions of temperature space where
     the energy is zero.
@@ -99,15 +90,10 @@ def filter_temperatures(desired_data):
     List[Dict[str, Any]]
 
     """
-    # TODO: can this copy be removed safely?
-    # This seems to be necessary because the 'values' member does not modify 'datasets'
-    # But everything else does!
-    desired_data = copy.deepcopy(desired_data)
-
-    for idx, data in enumerate(desired_data):
+    for data in desired_data:
         temp_filter = np.atleast_1d(data['conditions']['T']) >= 298.15
-        desired_data[idx]['conditions']['T'] = np.atleast_1d(data['conditions']['T'])[temp_filter]
-        desired_data[idx]['values'] = np.array(data['values'], dtype=np.float_)[..., temp_filter, :].tolist()
+        data['conditions']['T'] = np.atleast_1d(data['conditions']['T'])[temp_filter]
+        data['values'] = np.array(data['values'], dtype=np.float_)[..., temp_filter, :].tolist()
     return desired_data
 
 

--- a/espei/core_utils.py
+++ b/espei/core_utils.py
@@ -2,18 +2,19 @@
 Utilities for querying and modifiying datasets.
 """
 import copy
+from typing import List
 import numpy as np
 import tinydb
+from espei.datasets import Dataset
 from espei.sublattice_tools import canonicalize, recursive_tuplify
 
-
-def filter_configurations(desired_data, configuration, symmetry):
+def filter_configurations(desired_data: List[Dataset], configuration, symmetry) -> List[Dataset]:
     """
     Return non-equilibrium thermochemical datasets with invalid configurations removed.
 
     Parameters
     ----------
-    desired_data : List[Dict[str, Any]]
+    desired_data : List[Dataset]
         List of non-equilibrium thermochemical datasets
     configuration : tuple
         Sublattice configuration as a tuple, e.g. ("CU", ("CU", "MG"))
@@ -22,7 +23,7 @@ def filter_configurations(desired_data, configuration, symmetry):
 
     Returns
     -------
-    List[Dict[str, Any]]
+    List[Dataset]
 
     """
     for data in desired_data:
@@ -38,7 +39,7 @@ def filter_configurations(desired_data, configuration, symmetry):
     return desired_data
 
 
-def filter_temperatures(desired_data):
+def filter_temperatures(desired_data) -> List[Dataset]:
     """
     Return non-equilibrium thermochemical datasets with temperatures below 298.15 K removed.
 
@@ -50,12 +51,12 @@ def filter_temperatures(desired_data):
 
     Parameters
     ----------
-    desired_data : List[Dict[str, Any]]
+    desired_data : List[Dataset]
         List of non-equilibrium thermochemical datasets
 
     Returns
     -------
-    List[Dict[str, Any]]
+    List[Dataset]
 
     """
     for data in desired_data:
@@ -223,33 +224,6 @@ def ravel_zpf_values(desired_data, independent_comps, conditions=None):
     return equilibria_dict
 
 
-def recursive_map(f, x):
-    """
-    map, but over nested lists
-
-    Parameters
-    ----------
-    f : callable
-        Function to apply to x
-    x : list or value
-        Value passed to v
-
-    Returns
-    -------
-    list or value
-    """
-    if isinstance(x, list):
-        if [isinstance(xx, list) for xx in x]:
-            # we got a nested list
-            return [recursive_map(f, xx) for xx in x]
-        else:
-            # it's a list with some values inside
-            return list(map(f, x))
-    else:
-        # not a list, probably just a singular value
-        return f(x)
-
-
 def symmetry_filter(x, config, symmetry):
     """
     Return True if the candidate sublattice configuration has any symmetry
@@ -284,7 +258,7 @@ def symmetry_filter(x, config, symmetry):
     return False
 
 
-def get_prop_data(comps, phase_name, prop, datasets, additional_query=None):
+def get_prop_data(comps, phase_name, prop, datasets, additional_query=None) -> List[Dataset]:
     """
     Return a copy of datasets that match the components, phase and property.
 
@@ -305,8 +279,7 @@ def get_prop_data(comps, phase_name, prop, datasets, additional_query=None):
 
     Returns
     -------
-    list
-        List of dictionary datasets that match the criteria
+    List[Dataset]
 
     """
     if additional_query is None:

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -13,7 +13,7 @@ from tinydb import where
 from pycalphad import Model, ReferenceState, variables as v
 from pycalphad.core.utils import unpack_components, get_pure_elements
 
-from espei.core_utils import ravel_conditions, get_prop_data
+from espei.core_utils import ravel_conditions, get_prop_data, filter_temperatures
 from espei.utils import database_symbols_to_fit
 from espei.error_functions.zpf_error import update_phase_record_parameters
 from espei.shadow_functions import calculate_
@@ -198,6 +198,8 @@ def get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=None, symb
                 else:
                     exc_search = (where('excluded_model_contributions').test(lambda x: tuple(sorted(x)) == exclusion)) & (where('solver').exists())
                 curr_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=exc_search)
+                # TODO: run `core_utils.filter_configurations`
+                curr_data = filter_temperatures(curr_data)
                 calculate_dict = get_prop_samples(curr_data, constituents)
                 mod = Model(dbf, comps, phase_name, parameters=symbols_to_fit)
                 if prop.endswith('_FORM'):

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
 import numpy as np
 import tinydb
+from sympy import Symbol
 from pycalphad import Model, calculate, equilibrium, variables as v
 from pycalphad.core.utils import unpack_components
 from pycalphad.plot.utils import phase_legend

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -15,7 +15,7 @@ from pycalphad.plot.eqplot import eqplot, _map_coord_to_variable, unpack_conditi
 
 from espei.error_functions.non_equilibrium_thermochemical_error import get_prop_samples
 from espei.utils import bib_marker_map
-from espei.core_utils import get_data, ravel_zpf_values
+from espei.core_utils import get_prop_data, filter_configurations, filter_temperatures, symmetry_filter, ravel_zpf_values
 from espei.parameter_selection.utils import _get_sample_condition_dicts
 from espei.sublattice_tools import recursive_tuplify, endmembers_from_interaction
 from espei.utils import build_sitefractions
@@ -95,7 +95,10 @@ def plot_parameters(dbf, comps, phase_name, configuration, symmetry, datasets=No
         filtered_plots = []
         for x_val, y_val in plots:
             desired_props = [y_val.split('_')[0]+'_FORM', y_val] if y_val.endswith('_MIX') else [y_val]
-            data = get_data(comps, phase_name, configuration, symmetry, datasets, desired_props)
+            solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
+            data = get_prop_data(comps, phase_name, desired_props, datasets, additional_query=solver_qry)
+            data = filter_configurations(data, configuration, symmetry)
+            data = filter_temperatures(data)
             if len(data) > 0:
                 filtered_plots.append((x_val, y_val, data))
     elif require_data:
@@ -107,7 +110,10 @@ def plot_parameters(dbf, comps, phase_name, configuration, symmetry, datasets=No
         filtered_plots = []
         for x_val, y_val in plots:
             desired_props = [y_val.split('_')[0]+'_FORM', y_val] if y_val.endswith('_MIX') else [y_val]
-            data = get_data(comps, phase_name, configuration, symmetry, datasets, desired_props)
+            solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
+            data = get_prop_data(comps, phase_name, desired_props, datasets, additional_query=solver_qry)
+            data = filter_configurations(data, configuration, symmetry)
+            data = filter_temperatures(data)
             filtered_plots.append((x_val, y_val, data))
     else:
         filtered_plots = [(x_val, y_val, []) for x_val, y_val in plots]
@@ -548,7 +554,10 @@ def plot_interaction(dbf, comps, phase_name, configuration, output, datasets=Non
     prop = output.split('_MIX')[0]
     desired_props = (f"{prop}_MIX", f"{prop}_FORM")
     if datasets is not None:
-        desired_data = get_data(comps, phase_name, configuration, symmetry, datasets, desired_props)
+        solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
+        desired_data = get_prop_data(comps, phase_name, desired_props, datasets, additional_query=solver_qry)
+        desired_data = filter_configurations(desired_data, configuration, symmetry)
+        desired_data = filter_temperatures(desired_data)
     else:
         desired_data = []
 
@@ -673,7 +682,10 @@ def plot_endmember(dbf, comps, phase_name, configuration, output, datasets=None,
         plt.gca()
 
     if datasets is not None:
-        desired_data = get_data(comps, phase_name, configuration, symmetry, datasets, output)
+        solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
+        desired_data = get_prop_data(comps, phase_name, output, datasets, additional_query=solver_qry)
+        desired_data = filter_configurations(desired_data, configuration, symmetry)
+        desired_data = filter_temperatures(desired_data)
     else:
         desired_data = []
 

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import tinydb
 
-from espei.core_utils import get_prop_data, filter_configurations, filter_temperatures, symmetry_filter, recursive_map
+from espei.core_utils import get_prop_data, filter_configurations, filter_temperatures, symmetry_filter
+from espei.datasets import recursive_map
 from espei.sublattice_tools import recursive_tuplify
 from espei.utils import PickleableTinyDB, MemoryStorage
 from espei.error_functions.non_equilibrium_thermochemical_error import get_prop_samples

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
+import tinydb
 
-from espei.core_utils import get_data, recursive_map
+from espei.core_utils import get_prop_data, filter_configurations, filter_temperatures, symmetry_filter, recursive_map
+from espei.sublattice_tools import recursive_tuplify
 from espei.utils import PickleableTinyDB, MemoryStorage
 from espei.error_functions.non_equilibrium_thermochemical_error import get_prop_samples
 
@@ -33,7 +35,12 @@ def test_get_data_for_a_minimal_example():
     symmetry = None
     desired_props = ['HM_FORM']
 
-    desired_data = get_data(comps, phase_name, configuration, symmetry, datasets, desired_props)
+    # The following lines replace "get_data" in a more functional form
+    solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
+    desired_data = get_prop_data(comps, phase_name, desired_props, datasets, additional_query=solver_qry)
+    desired_data = filter_configurations(desired_data, configuration, symmetry)
+    desired_data = filter_temperatures(desired_data)
+
     assert len(desired_data) == 1
     desired_data = desired_data[0]
     assert desired_data['components'] == comps


### PR DESCRIPTION
These changes

1. further unify querying datasets between parameter selection/plotting and MCMC non-equilibrium thermochemical data
2. add a type alias for datasets as `Dataset`