### PR TITLE
MAINT: Pin compatible pycalphad to 0.8.x series

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,8 +8,7 @@ dependencies:
   - emcee<3
   - matplotlib-base
   - numpy
-#  - pycalphad>=0.8.4,<0.9
-  - pycalphad==0.8.4
+  - pycalphad>=0.8.4,<0.9
   - python-symengine
   - pyyaml
   - scikit-learn

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,8 @@ dependencies:
   - emcee<3
   - matplotlib-base
   - numpy
- - pycalphad>=0.8.4,<0.9
+#  - pycalphad>=0.8.4,<0.9
+  - pycalphad==0.8.4
   - python-symengine
   - pyyaml
   - scikit-learn

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,8 +8,7 @@ dependencies:
   - emcee<3
   - matplotlib-base
   - numpy
-#  - pycalphad>=0.8.4,<0.9
-  - pycalphad==0.8.4
+ - pycalphad>=0.8.4,<0.9
   - python-symengine
   - pyyaml
   - scikit-learn

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,8 @@ dependencies:
   - emcee<3
   - matplotlib-base
   - numpy
-  - pycalphad>=0.8.4,<0.9
+#  - pycalphad>=0.8.4,<0.9
+  - pycalphad==0.8.4
   - python-symengine
   - pyyaml
   - scikit-learn

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - emcee<3
   - matplotlib-base
   - numpy
-  - pycalphad>=0.8.4
+  - pycalphad>=0.8.4,<0.9
   - python-symengine
   - pyyaml
   - scikit-learn

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -441,7 +441,7 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         region_comps[region_comps.index(np.nan)] = 1 - np.nansum(region_comps)
         driving_force = np.multiply(target_hyperplane_chempots, region_comps).sum() - select_energy
         driving_force = float(driving_force)
-    print(vertex.phase_name, target_hyperplane_chempots, driving_force)
+    print(vertex.phase_name, target_hyperplane_chempots, driving_force, vertex.points)
     return driving_force
 
 

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -441,6 +441,7 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         region_comps[region_comps.index(np.nan)] = 1 - np.nansum(region_comps)
         driving_force = np.multiply(target_hyperplane_chempots, region_comps).sum() - select_energy
         driving_force = float(driving_force)
+    print(vertex.phase_name, target_hyperplane_chempots, driving_force)
     return driving_force
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'emcee<3',
         'matplotlib',
         'numpy',
-        'pycalphad>=0.8.4',
+        'pycalphad~=0.8.4',
         'pyyaml',
         'scikit-learn',
         'scipy',

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -274,6 +274,7 @@ def test_zpf_error_species(datasets_db):
     zpf_data = get_zpf_data(dbf, comps, phases, datasets_db, {})
     exact_likelihood = calculate_zpf_error(zpf_data, approximate_equilibrium=False)
     assert np.isclose(exact_likelihood, zero_error_probability)
+    raise
     approx_likelihood = calculate_zpf_error(zpf_data, approximate_equilibrium=True)
     assert np.isclose(approx_likelihood, zero_error_probability)
 


### PR DESCRIPTION
The next major version of pycalphad, v0.9, will have breaking changes for ESPEI. This change ensures that the next release of ESPEI will always be able to find a valid release version of pycalphad.