### PR TITLE
MAINT: Remove Database objects from `calculate_` and error functions

### DIFF
--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -96,7 +96,7 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, make_ca
             'eq_thermochemical_data': eq_thermochemical_data,
         },
         'thermochemical_kwargs': {
-            'dbf': dbf, 'thermochemical_data': thermochemical_data,
+            'thermochemical_data': thermochemical_data,
         },
         'activity_kwargs': {
             'dbf': dbf, 'comps': comps, 'phases': phases, 'datasets': datasets,

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -209,7 +209,7 @@ def calc_prop_differences(eqpropdata: EqPropData,
         cond_dict = OrderedDict(**pot_conds, **comp_conds)
         # str_statevar_dict must be sorted, assumes that pot_conds are.
         str_statevar_dict = OrderedDict([(str(key), vals) for key, vals in pot_conds.items()])
-        grid = calculate_(dbf, species, phases, str_statevar_dict, models, phase_records, pdens=50, fake_points=True)
+        grid = calculate_(species, phases, str_statevar_dict, models, phase_records, pdens=50, fake_points=True)
         multi_eqdata = _equilibrium(species, phase_records, cond_dict, grid)
         # TODO: could be kind of slow. Callables (which are cachable) must be built.
         propdata = _eqcalculate(dbf, species, phases, cond_dict, output, data=multi_eqdata, per_phase=False, callables=None, parameters=params_dict, model=models)

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -234,14 +234,12 @@ def get_thermochemical_data(dbf, comps, phases, datasets, weight_dict=None, symb
     return all_data_dicts
 
 
-def calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data, parameters=None):
+def calculate_non_equilibrium_thermochemical_probability(thermochemical_data, parameters=None):
     """
     Calculate the weighted single phase error in the Database
 
     Parameters
     ----------
-    dbf : pycalphad.Database
-        Database to consider
     thermochemical_data : list
         List of thermochemical data dicts
     parameters : np.ndarray

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -264,7 +264,7 @@ def calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_dat
         sample_values = data['calculate_dict']['values']
 
         update_phase_record_parameters(phase_records, parameters)
-        results = calculate_(dbf, data['species'], [phase_name],
+        results = calculate_(data['species'], [phase_name],
                              data['str_statevar_dict'], data['model'],
                              phase_records, output=output, broadcast=False,
                              points=data['calculate_dict']['points'])[output]

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -49,7 +49,6 @@ class RegionVertex:
 class PhaseRegion:
     vertices: Sequence[RegionVertex]
     potential_conds: Dict[v.StateVariable, float]
-    dbf: Database
     species: Sequence[v.Species]
     phases: Sequence[str]
     models: Dict[str, Model]
@@ -93,11 +92,8 @@ def _extract_phases_comps(vertex):
     return phase_name, comp_conds, disordered_flag
 
 
-def _phase_is_stoichiometric(dbf, species, phase_name):
-    phase_constituents = dbf.phases[phase_name].constituents
-    # phase constituents must be filtered to only active:
-    constituents = [[sp.name for sp in sorted(subl_constituents.intersection(species))] for subl_constituents in phase_constituents]
-    return all(len(subl) == 1 for subl in constituents)
+def _phase_is_stoichiometric(mod):
+    return all(len(subl) == 1 for subl in mod.constituents)
 
 
 def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float]):
@@ -147,20 +143,20 @@ def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], dat
                 phase_name, comp_conds, disordered_flag = _extract_phases_comps(vertex)
                 phase_recs = build_phase_records(dbf, species, data_phases, {**pot_conds, **comp_conds}, models, parameters=parameters, build_gradients=True, build_hessians=True)
                 # Construct single-phase points satisfying the conditions for each phase in the region
+                mod = models[phase_name]
                 if any(val is None for val in comp_conds.values()):
                     # We can't construct points because we don't have a known composition
                     has_missing_comp_cond = True
                     phase_points = None
-                elif _phase_is_stoichiometric(dbf, species, phase_name):
+                elif _phase_is_stoichiometric(mod):
                     has_missing_comp_cond = False
                     phase_points = None
                 else:
                     has_missing_comp_cond = False
-                    mod = models[phase_name]
                     phase_points = _sample_phase_constitution(mod, point_sample, True, 50)
                 vtx = RegionVertex(phase_name, comp_conds, phase_points, phase_recs, disordered_flag, has_missing_comp_cond)
                 vertices.append(vtx)
-            region = PhaseRegion(vertices, pot_conds, dbf, species, data_phases, models)
+            region = PhaseRegion(vertices, pot_conds, species, data_phases, models)
             phase_regions.append(region)
 
         data_dict = {
@@ -192,7 +188,6 @@ def estimate_hyperplane(phase_region: PhaseRegion, parameters: np.ndarray, appro
         _equilibrium = equilibrium_
     target_hyperplane_chempots = []
     target_hyperplane_phases = []
-    dbf = phase_region.dbf
     species = phase_region.species
     phases = phase_region.phases
     models = phase_region.models
@@ -233,7 +228,6 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         _equilibrium = no_op_equilibrium_
     else:
         _equilibrium = equilibrium_
-    dbf = phase_region.dbf
     species = phase_region.species
     models = phase_region.models
     current_phase = vertex.phase_name
@@ -254,23 +248,25 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         # Compute energy
         # Compute residual driving force
         # TODO: Check that it actually makes sense to declare this phase 'disordered'
-        num_dof = sum([len(set(c).intersection(species)) for c in dbf.phases[current_phase].constituents])
+        num_dof = sum([len(subl) for subl in models[current_phase].constituents])
         desired_sitefracs = np.ones(num_dof, dtype=np.float_)
         dof_idx = 0
-        for c in dbf.phases[current_phase].constituents:
-            dof = sorted(set(c).intersection(comps))
-            if (len(dof) == 1) and (dof[0] == 'VA'):
-                return 0
-            # If it's disordered config of BCC_B2 with VA, disordered config is tiny vacancy count
-            sitefracs_to_add = np.array([cond_dict.get(v.X(d)) for d in dof], dtype=np.float_)
-            # Fix composition of dependent component
-            sitefracs_to_add[np.isnan(sitefracs_to_add)] = 1 - np.nansum(sitefracs_to_add)
-            desired_sitefracs[dof_idx:dof_idx + len(dof)] = sitefracs_to_add
-            dof_idx += len(dof)
-        # TODO: we probably should be passing desired_sitefracs to calculate_
-        # here since the internal DOF is fixed. This should satisfy the same
-        # effect as passing phase_points in the other calls here.
-        single_eqdata = calculate_(species, [current_phase], str_statevar_dict, models, phase_records, pdens=50)
+        for subl in models[current_phase].constituents:
+            dof = sorted(subl, key=str)
+            num_subl_dof = len(subl)
+            if v.Species("VA") in dof:
+                if num_subl_dof == 1:
+                    _log.debug('Cannot predict the site fraction of vacancies in the disordered configuration %s of %s. Returning driving force of zero.', subl, current_phase)
+                    return 0
+                else:
+                    sitefracs_to_add = [1.0]
+            else:
+                sitefracs_to_add = np.array([cond_dict.get(v.X(d)) for d in dof], dtype=np.float_)
+                # Fix composition of dependent component
+                sitefracs_to_add[np.isnan(sitefracs_to_add)] = 1 - np.nansum(sitefracs_to_add)
+            desired_sitefracs[dof_idx:dof_idx + num_subl_dof] = sitefracs_to_add
+            dof_idx += num_subl_dof
+        single_eqdata = calculate_(species, [current_phase], str_statevar_dict, models, phase_records, points=np.asarray([desired_sitefracs]))
         driving_force = np.multiply(target_hyperplane_chempots, single_eqdata.X).sum(axis=-1) - single_eqdata.GM
         driving_force = float(np.squeeze(driving_force))
     else:

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -207,7 +207,7 @@ def estimate_hyperplane(phase_region: PhaseRegion, parameters: np.ndarray, appro
             # Extract chemical potential hyperplane from multi-phase calculation
             # Note that we consider all phases in the system, not just ones in this tie region
             str_statevar_dict = OrderedDict([(str(key), cond_dict[key]) for key in sorted(phase_region.potential_conds.keys(), key=str)])
-            grid = calculate_(dbf, species, phases, str_statevar_dict, models, phase_records, pdens=50, fake_points=True)
+            grid = calculate_(species, phases, str_statevar_dict, models, phase_records, pdens=50, fake_points=True)
             multi_eqdata = _equilibrium(species, phase_records, cond_dict, grid)
             target_hyperplane_phases.append(multi_eqdata.Phase.squeeze())
             # Does there exist only a single phase in the result with zero internal degrees of freedom?
@@ -246,7 +246,7 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         # We don't have the phase composition here, so we estimate the driving force.
         # Can happen if one of the composition conditions is unknown or if the phase is
         # stoichiometric and the user did not specify a valid phase composition.
-        single_eqdata = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=50)
+        single_eqdata = calculate_(species, [current_phase], str_statevar_dict, models, phase_records, pdens=50)
         df = np.multiply(target_hyperplane_chempots, single_eqdata.X).sum(axis=-1) - single_eqdata.GM
         driving_force = float(df.max())
     elif vertex.is_disordered:
@@ -270,12 +270,12 @@ def driving_force_to_hyperplane(target_hyperplane_chempots: np.ndarray, comps: S
         # TODO: we probably should be passing desired_sitefracs to calculate_
         # here since the internal DOF is fixed. This should satisfy the same
         # effect as passing phase_points in the other calls here.
-        single_eqdata = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, pdens=50)
+        single_eqdata = calculate_(species, [current_phase], str_statevar_dict, models, phase_records, pdens=50)
         driving_force = np.multiply(target_hyperplane_chempots, single_eqdata.X).sum(axis=-1) - single_eqdata.GM
         driving_force = float(np.squeeze(driving_force))
     else:
         # Extract energies from single-phase calculations
-        grid = calculate_(dbf, species, [current_phase], str_statevar_dict, models, phase_records, points=phase_points, pdens=50, fake_points=True)
+        grid = calculate_(species, [current_phase], str_statevar_dict, models, phase_records, points=phase_points, pdens=50, fake_points=True)
         converged, energy = constrained_equilibrium(species, phase_records, cond_dict, grid)
 
         if not converged:

--- a/espei/shadow_functions.py
+++ b/espei/shadow_functions.py
@@ -62,7 +62,7 @@ def _single_phase_start_point(conditions, state_variables, phase_records, grid):
 
 
 
-def calculate_(dbf: Database, species: Sequence[v.Species], phases: Sequence[str],
+def calculate_(species: Sequence[v.Species], phases: Sequence[str],
                str_statevar_dict: Dict[str, np.ndarray], models: Dict[str, Model],
                phase_records: Dict[str, PhaseRecord], output: Optional[str] = 'GM',
                points: Optional[Dict[str, np.ndarray]] = None,

--- a/espei/shadow_functions.py
+++ b/espei/shadow_functions.py
@@ -66,14 +66,14 @@ def calculate_(species: Sequence[v.Species], phases: Sequence[str],
                str_statevar_dict: Dict[str, np.ndarray], models: Dict[str, Model],
                phase_records: Dict[str, PhaseRecord], output: Optional[str] = 'GM',
                points: Optional[Dict[str, np.ndarray]] = None,
-               pdens: Optional[int] = 2000, broadcast: Optional[bool] = True,
+               pdens: Optional[int] = 50, broadcast: Optional[bool] = True,
                fake_points: Optional[bool] = False,
                ) -> LightDataset:
     """
     Quickly sample phase internal degree of freedom with virtually no overhead.
     """
     points_dict = unpack_kwarg(points, default_arg=None)
-    pdens_dict = unpack_kwarg(pdens, default_arg=2000)
+    pdens_dict = unpack_kwarg(pdens, default_arg=50)
     nonvacant_components = [x for x in sorted(species) if x.number_of_atoms > 0]
     maximum_internal_dof = max(prx.phase_dof for prx in phase_records.values())
     all_phase_data = []

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -58,7 +58,7 @@ def test_non_equilibrium_thermochemical_error_with_multiple_X_points(datasets_db
     phases = list(dbf.phases.keys())
     comps = ['CU', 'MG', 'VA']
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db)
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
 
     assert np.isclose(error, -4061.119001241541, rtol=1e-6)
 
@@ -71,7 +71,7 @@ def test_non_equilibrium_thermochemical_error_with_multiple_T_points(datasets_db
     phases = list(dbf.phases.keys())
     comps = ['CU', 'MG', 'VA']
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db)
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(error,-14.287293263253728, rtol=1e-6)
 
 
@@ -83,7 +83,7 @@ def test_non_equilibrium_thermochemical_error_with_multiple_T_X_points(datasets_
     phases = list(dbf.phases.keys())
     comps = ['CU', 'MG', 'VA']
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db)
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(float(error), -3282497.2380024833, rtol=1e-6)
 
 def test_non_equilibrium_thermochemical_error_for_mixing_entropy_error_is_excess_only(datasets_db):
@@ -134,7 +134,7 @@ def test_non_equilibrium_thermochemical_error_for_mixing_entropy_error_is_excess
     zero_error_prob = scipy.stats.norm(loc=0, scale=0.2).logpdf(0.0)  # SM weight = 0.2
     # Explicitly pass parameters={} to not try fitting anything
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db, symbols_to_fit=[])
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(error, zero_error_prob, atol=1e-6)
 
 
@@ -185,7 +185,7 @@ def test_non_equilibrium_thermochemical_error_for_of_enthalpy_mixing(datasets_db
     zero_error_prob = scipy.stats.norm(loc=0, scale=500.0).logpdf(0.0)  # HM weight = 500
     # Explicitly pass parameters={} to not try fitting anything
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db, symbols_to_fit=[])
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(error, zero_error_prob, atol=1e-6)
 
 
@@ -200,16 +200,16 @@ def test_subsystem_non_equilibrium_thermochemcial_probability(datasets_db):
 
     # Truth
     thermochemical_data = get_thermochemical_data(dbf_bin, ['CR', 'NI', 'VA'], phases, datasets_db)
-    bin_prob = calculate_non_equilibrium_thermochemical_probability(dbf_bin, thermochemical_data)
+    bin_prob = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
 
     # Getting binary subsystem data explictly (from binary input)
     thermochemical_data = get_thermochemical_data(dbf_tern, ['CR', 'NI', 'VA'], phases, datasets_db)
-    prob = calculate_non_equilibrium_thermochemical_probability(dbf_tern, thermochemical_data)
+    prob = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(prob, bin_prob)
 
     # Getting binary subsystem from ternary input
     thermochemical_data = get_thermochemical_data(dbf_tern, ['CR', 'FE', 'NI', 'VA'], phases, datasets_db)
-    prob = calculate_non_equilibrium_thermochemical_probability(dbf_tern, thermochemical_data)
+    prob = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(prob, bin_prob)
 
 
@@ -324,7 +324,7 @@ def test_non_equilibrium_thermochemcial_species(datasets_db):
     phases = ['LIQUID']
 
     thermochemical_data = get_thermochemical_data(dbf, ['LI', 'SN'], phases, datasets_db)
-    prob = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    prob = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     # Near zero error and non-zero error
     assert np.isclose(prob, (-7.13354663 + -22.43585011))
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -55,7 +55,7 @@ def test_lnprob_calculates_single_phase_probability_for_success(datasets_db):
     opt = EmceeOptimizer(dbf)
 
     thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db, symbols_to_fit=[param])
-    thermochemical_kwargs = {'dbf': dbf, 'thermochemical_data': thermochemical_data}
+    thermochemical_kwargs = {'thermochemical_data': thermochemical_data}
     res_orig = opt.predict([orig_val], prior_rvs=[rv_zero()], symbols_to_fit=[param], thermochemical_kwargs=thermochemical_kwargs)
     assert np.isreal(res_orig)
     assert np.isclose(res_orig, -9.119484935312146, rtol=1e-6)

--- a/tests/test_parameter_generation.py
+++ b/tests/test_parameter_generation.py
@@ -140,7 +140,7 @@ def test_mixing_energies_are_fit(datasets_db):
     zero_error_prob = scipy.stats.norm(loc=0, scale=500.0).logpdf(0.0)  # HM weight = 500
     # Explicitly pass parameters={} to not try fitting anything
     thermochemical_data = get_thermochemical_data(dbf, sorted(read_dbf.elements), list(read_dbf.phases.keys()), datasets_db, symbols_to_fit=[])
-    error = calculate_non_equilibrium_thermochemical_probability(dbf, thermochemical_data)
+    error = calculate_non_equilibrium_thermochemical_probability(thermochemical_data)
     assert np.isclose(error, zero_error_prob, atol=1e-6)
 
 def test_duplicate_parameters_are_not_added_with_input_database(datasets_db):


### PR DESCRIPTION
Migrating to the new API for `pycalphad.core.calculate._sample_phase_constitution` removed the need for Database objects in error functions.