### PR TITLE
ENH: Enable custom Model classes in MCMC

### DIFF
--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -223,17 +223,17 @@ def get_thermochemical_data(dbf, comps, phases, datasets, model=None, weight_dic
                         mod.reference_model.models[contrib] = sympy.S.Zero
                 species = sorted(unpack_components(dbf, comps), key=str)
                 data_dict['species'] = species
-                model = {phase_name: mod}
+                model_dict = {phase_name: mod}
                 statevar_dict = {getattr(v, c, None): vals for c, vals in calculate_dict.items() if isinstance(getattr(v, c, None), v.StateVariable)}
                 statevar_dict = OrderedDict(sorted(statevar_dict.items(), key=lambda x: str(x[0])))
                 str_statevar_dict = OrderedDict((str(k), vals) for k, vals in statevar_dict.items())
-                phase_records = build_phase_records(dbf, species, [phase_name], statevar_dict, model,
+                phase_records = build_phase_records(dbf, species, [phase_name], statevar_dict, model_dict,
                                                     output=output, parameters={s: 0 for s in symbols_to_fit},
                                                     build_gradients=False, build_hessians=False)
                 data_dict['str_statevar_dict'] = str_statevar_dict
                 data_dict['phase_records'] = phase_records
                 data_dict['calculate_dict'] = calculate_dict
-                data_dict['model'] = model
+                data_dict['model'] = model_dict
                 data_dict['output'] = output
                 data_dict['weights'] = np.array(property_std_deviation[prop.split('_')[0]])/np.array(calculate_dict.pop('weights'))
                 all_data_dicts.append(data_dict)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -17,7 +17,7 @@ composition conditions to calculate chemical potentials at.
 import logging
 from dataclasses import dataclass
 from collections import OrderedDict
-from typing import Sequence, Dict, Any, Union, List, Tuple
+from typing import Sequence, Dict, Any, Union, List, Tuple, Type, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -130,7 +130,7 @@ def _subsample_phase_points(phase_record, phase_points, target_composition, avg_
     return phase_points[idxs]
 
 
-def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float]):
+def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], datasets: PickleableTinyDB, parameters: Dict[str, float], model: Optional[Dict[str, Type[Model]]] = None):
     """
     Return the ZPF data used in the calculation of ZPF error
 
@@ -144,6 +144,8 @@ def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], dat
         Datasets that contain single phase data
     parameters : dict
         Dictionary mapping symbols to optimize to their initial values
+    model : Optional[Dict[str, Type[Model]]]
+        Dictionary phase names to pycalphad Model classes.
 
     Returns
     -------
@@ -159,7 +161,7 @@ def get_zpf_data(dbf: Database, comps: Sequence[str], phases: Sequence[str], dat
         data_comps = list(set(data['components']).union({'VA'}))
         species = sorted(unpack_components(dbf, data_comps), key=str)
         data_phases = filter_phases(dbf, species, candidate_phases=phases)
-        models = instantiate_models(dbf, species, data_phases, parameters=parameters)
+        models = instantiate_models(dbf, species, data_phases, model=model, parameters=parameters)
         all_phase_points = {phase_name: _sample_phase_constitution(models[phase_name], point_sample, True, 50) for phase_name in data_phases}
         all_regions = data['values']
         conditions = data['conditions']

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -118,7 +118,9 @@ def _compute_vertex_composition(comps: Sequence[str], comp_conds: Dict[str, floa
 def _subsample_phase_points(phase_record, phase_points, target_composition, avg_mass_residual_tol=0.02):
     # Compute the mole fractions of each point
     phase_compositions = np.zeros((phase_points.shape[0], target_composition.size), order='F')
-    statevar_placeholder = np.zeros((phase_points.shape[0], 3))  # assume N, P, T
+    # TODO: potential bug here if the composition has dependence (even piecewise
+    #   dependence) in the state variables. The compositions may be nan in this case.
+    statevar_placeholder = np.ones((phase_points.shape[0], phase_record.num_statevars))
     dof = np.hstack((statevar_placeholder, phase_points))
     for el_idx in range(target_composition.size):
         phase_record.mass_obj_2d(phase_compositions[:, el_idx], dof, el_idx)

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -246,7 +246,7 @@ def run_espei(run_settings):
         approximate_equilibrium = mcmc_settings.get('approximate_equilibrium')
 
         # set up and run the EmceeOptimizer
-        optimizer = EmceeOptimizer(dbf, scheduler=client)
+        optimizer = EmceeOptimizer(dbf, phase_models=phase_models, scheduler=client)
         optimizer.save_interval = save_interval
         all_symbols = syms if syms is not None else database_symbols_to_fit(dbf)
         optimizer.fit(all_symbols, datasets, prior=prior, iterations=iterations,

--- a/espei/optimizers/opt_mcmc.py
+++ b/espei/optimizers/opt_mcmc.py
@@ -37,8 +37,9 @@ class EmceeOptimizer(OptimizerBase):
     [1] Goodman and Weare, Ensemble Samplers with Affine Invariance. Commun. Appl. Math. Comput. Sci. 5, 65-80 (2010).
     [2] Foreman-Mackey, Hogg, Lang, Goodman, emcee: The MCMC Hammer. Publ. Astron. Soc. Pac. 125, 306-312 (2013).
     """
-    def __init__(self, dbf, scheduler=None):
+    def __init__(self, dbf, phase_models=None, scheduler=None):
         super(EmceeOptimizer, self).__init__(dbf)
+        self.phase_models = phase_models
         self.scheduler = scheduler
         self.save_interval = 1
         # These are set by the _fit method
@@ -228,7 +229,7 @@ class EmceeOptimizer(OptimizerBase):
         # Set NumPy print options so logged arrays print on one line. Reset at the end.
         np.set_printoptions(linewidth=sys.maxsize)
         cbs = self.scheduler is None
-        ctx = setup_context(self.dbf, ds, symbols, data_weights=mcmc_data_weights, make_callables=cbs)
+        ctx = setup_context(self.dbf, ds, symbols, data_weights=mcmc_data_weights, phase_models=self.phase_models, make_callables=cbs)
         symbols_to_fit = ctx['symbols_to_fit']
         initial_guess = np.array([unpack_piecewise(self.dbf.symbols[s]) for s in symbols_to_fit])
 

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -4,6 +4,8 @@ Utilities for ESPEI
 Classes and functions defined here should have some reuse potential.
 """
 
+from typing import Any
+import importlib
 import itertools
 import re
 from collections import namedtuple
@@ -373,3 +375,25 @@ def extract_aliases(phase_models):
             else:
                 raise ValueError(f"Cannot add {alias} as an alias for {phase_name} because it is already used by {aliases[alias]}")
     return aliases
+
+
+def import_qualified_object(obj_path: str) -> Any:
+    """
+    Import an object from a fully qualified import path.
+
+    Returns
+    -------
+    Any
+
+    Examples
+    --------
+    >>> Mod = import_qualified_object('pycalphad.model.Model')
+    >>> from pycalphad.model import Model
+    >>> assert Mod is Model
+    """
+    split_path = obj_path.split('.')
+    module_import_path = '.'.join(split_path[:-1])
+    obj_name = split_path[-1]
+    mod = importlib.import_module(module_import_path)
+    obj = getattr(mod, obj_name)
+    return obj

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -4,7 +4,7 @@ Utilities for ESPEI
 Classes and functions defined here should have some reuse potential.
 """
 
-from typing import Any
+from typing import Any, Dict, Type
 import importlib
 import itertools
 import re
@@ -13,7 +13,7 @@ from collections import namedtuple
 import numpy as np
 import sympy
 from distributed import Client
-from pycalphad import variables as v
+from pycalphad import Model, variables as v
 from sympy import Symbol
 from tinydb import TinyDB, where
 from tinydb.storages import MemoryStorage
@@ -381,12 +381,9 @@ def import_qualified_object(obj_path: str) -> Any:
     """
     Import an object from a fully qualified import path.
 
-    Returns
-    -------
-    Any
-
     Examples
     --------
+    >>> from espei.utils import import_qualified_object
     >>> Mod = import_qualified_object('pycalphad.model.Model')
     >>> from pycalphad.model import Model
     >>> assert Mod is Model
@@ -397,3 +394,29 @@ def import_qualified_object(obj_path: str) -> Any:
     mod = importlib.import_module(module_import_path)
     obj = getattr(mod, obj_name)
     return obj
+
+
+# TODO: Type[Model] should be updated to Type[ModelProtocol] when that exists
+def get_model_dict(phase_models: dict) -> Dict[str, Type[Model]]:
+    """
+    Return a pycalphad-style model dictionary mapping phase names to model classes.
+
+    If a phase's "model" key is not specified, no entry is created. In practice, the
+    behavior of the defaults would be handled by pycalphad.
+
+    Parameters
+    ----------
+    phase_models : dict
+        ESPEI-style phase models dictionary
+
+    Returns
+    -------
+    Any
+
+    """
+    model_dict = {}
+    for phase_name, phase_dict in phase_models["phases"].items():
+        qualified_model_class = phase_dict.get("model")
+        if qualified_model_class is not None:
+            model_dict[phase_name] = import_qualified_object(qualified_model_class)
+    return model_dict

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -377,7 +377,7 @@ def test_equilibrium_thermochemical_error_computes_correct_probability(datasets_
     assert np.all(np.isclose(errors, expected_vals))
 
     # VV0017 (LIQUID, L0)
-    eqdata = get_equilibrium_thermochemical_data(dbf, ['CU', 'MG'], phases, datasets_db, {'VV0017': -31626.6})
+    eqdata = get_equilibrium_thermochemical_data(dbf, ['CU', 'MG'], phases, datasets_db, parameters={'VV0017': -31626.6})
     # unchanged, should be the same as before
     errors, weights = calc_prop_differences(eqdata[0], np.array([-31626.6]))
     assert np.all(np.isclose(errors, [-31626.6*0.5*0.5]))


### PR DESCRIPTION
The idea is that phase models can now have an optional `"model"` key for each phase that is a fully qualified import path to a class that follows pycalphad's Model protocol.

```json
{
  "components": ["CU", "MG", "VA"],
  "phases": {
         "LIQUID" : {
            "sublattice_model": [["CU", "MG"]],
            "sublattice_site_ratios": [1],
            "model": "mypackage.mymodule.MyModel"
         },
         "FCC_A1": {
            "sublattice_model": [["CU", "MG"], ["VA"]],
            "sublattice_site_ratios": [1, 1]
         }
    }
}
```