### PR TITLE
BLD/MAINT: Pin Python version for sphinx-build action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
       # Development version for development docs
       - name: Install pycalphad development version
         run: pip install git+https://github.com/pycalphad/pycalphad.git@develop


### PR DESCRIPTION
Python 3.10 not supported by some runtime dependencies yet (see https://github.com/pycalphad/pycalphad/pull/374).