### PR TITLE
MAINT: scikit-learn: remove normalize parameter

### DIFF
--- a/docs/input_data.rst
+++ b/docs/input_data.rst
@@ -129,7 +129,7 @@ Two examples follow. The first dataset has some data for the formation heat capa
    See the second example in this section for such an example.
 
 * The ``conditions`` describe temperatures (``T``) and pressures (``P``) as either scalars or one-dimensional lists.
-* The type of quantity is expressed using the ``output`` key. This can in principle be any thermodynamic quantity, but currently only ``CPM*``, ``SM*``, and ``HM*`` (where ``*`` is either nothing, ``_MIX`` or ``_FORM``) are supported. Support for changing reference states is planned but not yet implemented, so all thermodynamic quantities must be formation quantities (e.g. ``HM_FORM`` or ``HM_MIX``, etc.). This issue is tracked by `ESPEI #85 on GitHub <https://github.com/PhasesResearchLab/ESPEI/issues/85>`_
+* The type of quantity is expressed using the ``output`` key. This can in principle be any thermodynamic quantity, but currently only ``CPM*``, ``SM*``, and ``HM*`` (where ``*`` is either nothing, ``_MIX`` or ``_FORM``) are supported. Support for changing reference states is planned but not yet implemented, so all thermodynamic quantities must be formation quantities (e.g. ``HM_FORM`` or ``HM_MIX``, etc.). This is tracked by :issue:`85` on GitHub.
 * ``values`` is a 3-dimensional array where each value is the ``output`` for a specific condition of pressure, temperature, and sublattice configurations from outside to inside. Alternatively, the size of the array must be ``(len(P), len(T), len(subl_config))``. In the example below, the shape of the ``values`` array is (1, 12, 1) as there is one pressure scalar, one sublattice configuration, and 12 temperatures.
 * There is also a key, ``excluded_model_contributions``, which will make those contributions of pycalphad's ``Model`` not be fit to when doing parameter selection or MCMC. This is useful for cases where the type of data used does not include some specific ``Model`` contributions that parameters may already exist for. For example, DFT formation energies do not include ideal mixing or (CALPHAD-type) magnetic model contributions, but formation energies from experiments would include these contributions so experimental formation energies should not be excluded.
 
@@ -236,7 +236,7 @@ This type of data can not be used in parameter selection, because a core assumpt
 
 .. note::
 
-  Only activity data is supported at the moment. Support for other data types is tracked by `ESPEI #104 on GitHub <https://github.com/PhasesResearchLab/ESPEI/issues/104>`_.
+  Only activity data is supported at the moment. Support for other data types is tracked by :issue:`104`.
 
 Activity data is similar to non-equilibrium thermochemical data, except we must enter a reference state and the ``solver`` key is no longer required, since we do not know the internal degrees of freedom. A key detail is that the ``phases`` key must specify all phases that are possible to form.
 

--- a/espei/parameter_selection/selection.py
+++ b/espei/parameter_selection/selection.py
@@ -37,9 +37,9 @@ def fit_model(feature_matrix, data_quantities, ridge_alpha, weights=None):
 
     """
     if ridge_alpha is not None:
-        clf = Ridge(fit_intercept=False, normalize=True, alpha=ridge_alpha)
+        clf = Ridge(fit_intercept=False, alpha=ridge_alpha)
     else:
-        clf = LinearRegression(fit_intercept=False, normalize=True)
+        clf = LinearRegression(fit_intercept=False)
     clf.fit(feature_matrix, data_quantities, sample_weight=weights)
     return clf.coef_
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'pycalphad>=0.9.2',
         'pyyaml',
         'setuptools_scm[toml]>=6.0',
-        'scikit-learn',
+        'scikit-learn>=1.0',
         'scipy',
         'symengine',
         'sympy>=1.5.1',


### PR DESCRIPTION
The `normalize` parameter was deprecated in scikit-learn 1.0. It does no take effect when `fit_intercept=False` (which we have always used), so we can simply remove it. See https://scikit-learn.org/1.0/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression for more details.