### PR TITLE
MAINT: Remove all matplotlib gca() calls

### DIFF
--- a/docs/cu-mg-example.rst
+++ b/docs/cu-mg-example.rst
@@ -320,7 +320,7 @@ after 115 iterations.
     trace, lnprob = truncate_arrays(trace, lnprob)
 
 
-    ax = plt.gca()
+    ax = plt.subplot()
     ax.set_yscale('log')
     ax.set_ylim(1e7, 1e10)
     ax.set_xlabel('Iterations')
@@ -360,7 +360,7 @@ parameters explore the space and converge to a solution.
     num_chains = trace.shape[0]
     num_parameters = 3 # only plot the first three parameter, for all of them use `trace.shape[2]`
     for parameter in range(num_parameters):
-        ax = plt.figure().gca()
+        fig, ax = plt.subplots()
         ax.set_xlabel('Iterations')
         ax.set_ylabel('Parameter value')
         for chain in range(num_chains):

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -116,8 +116,7 @@ Plot phase diagram with data
    conds = {v.P: 101325, v.T: (700, 2200, 10), v.X("CR"): (0, 1, 0.01)}
 
    # plot the phase diagram and data
-   fig = plt.figure(dpi=150)
-   ax = fig.gca()
+   fig, ax = plt.sublots(dpi=150)
    binplot(dbf, comps, phases, conds, plot_kwargs={"ax": ax})
    dataplot(comps, phases, conds, datasets, ax=ax)
    ax.set_title("Cr-Ni\nParameter Generation")
@@ -203,7 +202,7 @@ log-probability changes for all of the chains as a function of iterations.
     trace, lnprob = truncate_arrays(trace, lnprob)
 
 
-    ax = plt.gca()
+    ax = plt.subplot()
     ax.set_yscale('log')
     ax.set_xlabel('Iterations')
     ax.set_ylabel('- lnprob')
@@ -240,7 +239,7 @@ are relative to each other.
     num_chains = trace.shape[0]
     num_parameters = trace.shape[2]
     for parameter in range(num_parameters):
-        ax = plt.figure().gca()
+        fig, ax = plt.subplots()  # new figure for every parameter
         ax.set_xlabel('Iterations')
         ax.set_ylabel('Parameter value')
         ax.plot(trace[..., parameter].T)
@@ -352,8 +351,7 @@ log-likelihood of each driving force.
                    Xs.append(1.0 - tuple(comp_cond.values())[0])
 
    # Plot the phase diagram with driving forces
-   fig = plt.figure(dpi=100)
-   ax = fig.gca()
+   fig, ax = plt.subplots(dpi=100)
    binplot(dbf, COMPS, phases, CONDS, plot_kwargs={'ax': ax}, eq_kwargs={'parameters': parameters})
    sm = plt.cm.ScalarMappable(cmap=CMAP)
    sm.set_array(dfs)

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -197,7 +197,7 @@ def dataplot(comps, phases, conds, datasets, tielines=True, ax=None, plot_kwargs
 
     # set up plot if not done already
     if ax is None:
-        ax = plt.gca(projection=projection)
+        ax = plt.subplot(projection=projection)
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         ax.tick_params(axis='both', which='major', labelsize=14)
@@ -542,7 +542,7 @@ def plot_interaction(dbf, comps, phase_name, configuration, output, datasets=Non
         dataplot_kwargs = {}
 
     if not ax:
-        ax = plt.gca()
+        ax = plt.subplot()
 
     # Plot predicted values from the database
     grid, predicted_values = _get_interaction_predicted_values(dbf, comps, phase_name, configuration, output)
@@ -685,7 +685,7 @@ def plot_endmember(dbf, comps, phase_name, configuration, output, datasets=None,
         dataplot_kwargs = {}
 
     if not ax:
-        ax = plt.gca()
+        ax = plt.subplot()
 
     if datasets is not None:
         solver_qry = (tinydb.where('solver').test(symmetry_filter, configuration, recursive_tuplify(symmetry) if symmetry else symmetry))
@@ -792,8 +792,7 @@ def _compare_data_to_parameters(dbf, comps, phase_name, desired_data, mod, confi
         endpoints = [endpoints[0], endpoints[-1]]
         disordered_config = True
     if not ax:
-        fig = plt.figure(figsize=plt.figaspect(1))
-        ax = fig.gca()
+        ax = plt.subplot()
     bar_chart = False
     bar_labels = []
     bar_data = []


### PR DESCRIPTION
Use of projections in `gca(projection=...)` are deprecated and more modern matplotlib seems to recommend `plt.subplot` instead of `gca` and `plt.subplots` to create new figures and axes.