### PR TITLE
FIX: Fix generate_symmetric_group for FCC 4SL

### DIFF
--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -103,17 +103,16 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
 
     Notes
     -----
-    Technically, equivalency between sublattices (`[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`)
-    is not necessarily required. It could be that sublattices 0 and 1 represent
-    equivalent substitutional sublattices, while 2 and 3 represent equivalent
-    interstitial sites. Constituent interchange would be possible between substitutional sublattices,
-    but the substitutional sites would not be interchangeable with the interstitial
-    sites.
-
-    Since this function is primarily used for models where the with symmetries are
-    interchanable (ordered bcc configurations in particular), we choose to neglect that
-    case here.
-
+    In the general case, equivalency between sublattices, for example
+    (`[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`), is not necessarily required. It
+    could be that sublattices 0 and 1 represent equivalent substitutional
+    sublattices, while 2 and 3 represent equivalent interstitial sites.
+    Interchange sublattices between substitutional sublattices is allowed, but
+    the substitutional sites would not be interchangeable with the interstitial
+    sites. To achieve this kind of effect with this function, you would need to
+    call it once with the equivlanet substitutional sublattices, then for each
+    generated configuration, call this function again, giving the equivalent
+    interstitial sublattices.
     """
     # recursively casting sequences to tuples ensures that the generated configurations are hashable
     configuration = recursive_tuplify(configuration)

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -107,12 +107,12 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
     (`[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`), is not necessarily required. It
     could be that sublattices 0 and 1 represent equivalent substitutional
     sublattices, while 2 and 3 represent equivalent interstitial sites.
-    Interchange sublattices between substitutional sublattices is allowed, but
+    Interchanging sublattices between substitutional sublattices is allowed, but
     the substitutional sites would not be interchangeable with the interstitial
     sites. To achieve this kind of effect with this function, you would need to
-    call it once with the equivlanet substitutional sublattices, then for each
-    generated configuration, call this function again, giving the equivalent
-    interstitial sublattices.
+    call it once with the equivalent substitutional sublattices, then for each
+    generated configuration, call this function again, giving the unique
+    configurations for symmetric interstitial sublattices.
     """
     # recursively casting sequences to tuples ensures that the generated configurations are hashable
     configuration = recursive_tuplify(configuration)

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -91,7 +91,7 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
         sublattices are internally equivalent and the sublattices themselves are assumed
         interchangeble. That is, for a symmetry of `[[0, 1], [2, 3]]`, sublattices
         0 and 1 are equivalent to each other (i.e. `[0, 1] == [1, 0]`) and similarly for
-        sublattices 2 and 3. It also implies that the sublattices are interchangable,
+        sublattices 2 and 3. It also implies that the sublattices are interchangeable,
         (i.e. `[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`), but note that constituents cannot
         change sublattices (i.e. `[[0, 1], [2, 3]] != [[0, 3], [2, 1]]`).
          If `symmetry=None` is given, no new configurations are generated.
@@ -107,7 +107,7 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
     is not necessarily required. It could be that sublattices 0 and 1 represent
     equivalent substitutional sublattices, while 2 and 3 represent equivalent
     interstitial sites. Constituent interchange would be possible within a sublattice,
-    but the substitutional sites would not be interchangable with the interstitial
+    but the substitutional sites would not be interchangeable with the interstitial
     sites.
 
     Since this function is primarily used for models where the with symmetries are

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -89,10 +89,8 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
         given, `symmetry` _must_ contain all sublattice indices exactly once. For
         example: `[[0, 1], [2, 3]]` means that sublattices 0 and 1 are equivalent to
         each other and sublattices 2 and 3 are also equivalent to each other. Symmetry
-        of `[[0, 1, 2, 3], [4]]` means that the first four sublattices are symmetric to
-        each other and the last sublattice is not equivalent to any other sublattice.
-        If `None` is given as the value, it is assumed that all sublattices are
-        inequivalent.
+        of `[[0, 1, 2, 3]]` means that the first four sublattices are symmetric to
+        each other. If `None` is given, no new configurations are generated.
 
     Returns
     -------
@@ -103,8 +101,7 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
     configuration = recursive_tuplify(configuration)  # ensures that the generated configurations are
     sublattice_indices = list(range(len(configuration)))
     if symmetry is None:
-        # Each sublattice is independent and only symmetric with itself.
-        symmetry = [[i] for i in sublattice_indices]
+        return [configuration]
     seen_subl_indices = sorted([i for equiv_subl in symmetry for i in equiv_subl])
     if (sublattice_indices != seen_subl_indices) or (set(sublattice_indices) != set(seen_subl_indices)):
         raise ValueError(f"Expected that the entries of `symmetry` give each sublattice index exactly once. Got {len(sublattice_indices)} sublattices with indices {sublattice_indices} for symmetry {symmetry}")

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -106,7 +106,7 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
     Technically, equivalency between sublattices (`[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`)
     is not necessarily required. It could be that sublattices 0 and 1 represent
     equivalent substitutional sublattices, while 2 and 3 represent equivalent
-    interstitial sites. Constituent interchange would be possible within a sublattice,
+    interstitial sites. Constituent interchange would be possible between substitutional sublattices,
     but the substitutional sites would not be interchangeable with the interstitial
     sites.
 

--- a/espei/sublattice_tools.py
+++ b/espei/sublattice_tools.py
@@ -94,7 +94,7 @@ def generate_symmetric_group(configuration: Sequence[Any], symmetry: Union[None,
         sublattices 2 and 3. It also implies that the sublattices are interchangeable,
         (i.e. `[[0, 1], [2, 3]] == [[2, 3], [0, 1]]`), but note that constituents cannot
         change sublattices (i.e. `[[0, 1], [2, 3]] != [[0, 3], [2, 1]]`).
-         If `symmetry=None` is given, no new configurations are generated.
+        If `symmetry=None` is given, no new configurations are generated.
 
     Returns
     -------

--- a/tests/test_model_building.py
+++ b/tests/test_model_building.py
@@ -126,6 +126,19 @@ def test_symmetric_group_can_be_generated_for_2_sl_endmembers_with_symmetry():
     assert symm_groups == [('AL', 'CO'), ('CO', 'AL')]
 
 
+def test_generating_symmetric_group_works_without_symmetry():
+    """generate_symmetric_group returns the passed configuration if symmetry=None"""
+
+    config_D03_A3B = ["A", "A", "A", "B"]
+    symm_groups = generate_symmetric_group(config_D03_A3B, None)
+    assert symm_groups == [("A", "A", "A", "B")]
+
+    symm_groups = generate_symmetric_group((("CR", "FE"), "VA"), None)
+    assert symm_groups == [
+        (("CR", "FE"), "VA")
+    ]
+
+
 def test_generating_symmetric_group_bcc_4sl():
     """Binary BCC 4SL ordered symmetric configurations can can be generated"""
     bcc_4sl_symmetry = [[0, 1], [2, 3]]
@@ -179,6 +192,51 @@ def test_generating_symmetric_group_fcc_4sl():
         ("B", "A", "B", "A"),
         ("B", "B", "A", "A"),
     ]
+
+
+def test_generating_symmetric_group_works_with_interstitial_sublattice():
+    """Symmetry groups for phases with an inequivalent vacancy sublattice are correctly generated"""
+    bcc_4sl_symmetry = [[0, 1], [2, 3]]
+    config_D03_A3B = ["A", "A", "A", "B", "VA"]
+    symm_groups = generate_symmetric_group(config_D03_A3B, bcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "A", "B", "VA"),
+        ("A", "A", "B", "A", "VA"),
+        ("A", "B", "A", "A", "VA"),
+        ("B", "A", "A", "A", "VA"),
+    ]
+
+    fcc_4sl_symmetry = [[0, 1, 2, 3]]
+    config_L1_2_A3B = ["A", "A", "A", "B", "VA"]
+    symm_groups = generate_symmetric_group(config_L1_2_A3B, fcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "A", "B", "VA"),
+        ("A", "A", "B", "A", "VA"),
+        ("A", "B", "A", "A", "VA"),
+        ("B", "A", "A", "A", "VA"),
+    ]
+
+    # "Unrealistic" cases where the vacancy sublattice is in the middle at index 2
+    bcc_4sl_symmetry = [[0, 1], [3, 4]]
+    config_D03_A3B = ["A", "A", "VA", "A", "B"]
+    symm_groups = generate_symmetric_group(config_D03_A3B, bcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "VA", "A", "B"),
+        ("A", "A", "VA", "B", "A"),
+        ("A", "B", "VA", "A", "A"),
+        ("B", "A", "VA", "A", "A"),
+    ]
+
+    fcc_4sl_symmetry = [[0, 1, 3, 4]]
+    config_L1_2_A3B = ["A", "A", "VA", "A", "B"]
+    symm_groups = generate_symmetric_group(config_L1_2_A3B, fcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "VA", "A", "B"),
+        ("A", "A", "VA", "B", "A"),
+        ("A", "B", "VA", "A", "A"),
+        ("B", "A", "VA", "A", "A"),
+    ]
+
 
 
 def test_interaction_sorting_is_correct():

--- a/tests/test_model_building.py
+++ b/tests/test_model_building.py
@@ -126,6 +126,36 @@ def test_symmetric_group_can_be_generated_for_2_sl_endmembers_with_symmetry():
     assert symm_groups == [('AL', 'CO'), ('CO', 'AL')]
 
 
+def test_generating_symmetric_group_bcc_4sl():
+    """Binary BCC 4SL ordered symmetric configurations can can be generated"""
+    bcc_4sl_symmetry = [[0, 1], [2, 3]]
+
+    config_D03_A3B = ["A", "A", "A", "B"]
+    symm_groups = generate_symmetric_group(config_D03_A3B, bcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "A", "B"),
+        ("A", "A", "B", "A"),
+        ("A", "B", "A", "A"),
+        ("B", "A", "A", "A"),
+    ]
+
+    config_B2_A2B2 = ["A", "A", "B", "B"]
+    symm_groups = generate_symmetric_group(config_B2_A2B2, bcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "B", "B"),
+        ("B", "B", "A", "A"),
+    ]
+
+    config_B32_A2B2 = ["A", "B", "A", "B"]
+    symm_groups = generate_symmetric_group(config_B32_A2B2, bcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "B", "A", "B"),
+        ("A", "B", "B", "A"),
+        ("B", "A", "A", "B"),
+        ("B", "A", "B", "A"),
+    ]
+
+
 def test_interaction_sorting_is_correct():
     """High order (order >= 3) interactions should sort correctly"""
     # Correct sorting of n-order interactions should sort first by number of
@@ -157,4 +187,3 @@ def test_interaction_sorting_is_correct():
         ('CO', ('AL', 'CO', 'CR')),                # (1, 0, 1)
         ('CR', ('AL', 'CO', 'CR')),                # (1, 0, 1)
     ]
-

--- a/tests/test_model_building.py
+++ b/tests/test_model_building.py
@@ -156,6 +156,31 @@ def test_generating_symmetric_group_bcc_4sl():
     ]
 
 
+def test_generating_symmetric_group_fcc_4sl():
+    """Binary FCC 4SL ordered symmetric configurations can can be generated"""
+    fcc_4sl_symmetry = [[0, 1, 2, 3]]
+
+    config_L1_2_A3B = ["A", "A", "A", "B"]
+    symm_groups = generate_symmetric_group(config_L1_2_A3B, fcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "A", "B"),
+        ("A", "A", "B", "A"),
+        ("A", "B", "A", "A"),
+        ("B", "A", "A", "A"),
+    ]
+
+    config_L1_0_A2B2 = ["A", "A", "B", "B"]
+    symm_groups = generate_symmetric_group(config_L1_0_A2B2, fcc_4sl_symmetry)
+    assert symm_groups == [
+        ("A", "A", "B", "B"),
+        ("A", "B", "A", "B"),
+        ("A", "B", "B", "A"),
+        ("B", "A", "A", "B"),
+        ("B", "A", "B", "A"),
+        ("B", "B", "A", "A"),
+    ]
+
+
 def test_interaction_sorting_is_correct():
     """High order (order >= 3) interactions should sort correctly"""
     # Correct sorting of n-order interactions should sort first by number of


### PR DESCRIPTION
Complete rewrite of the `generate_symmetric_group`, preserving the existing API.

- Fixes a bug where the permutations of a 4 sublattice fcc phase with symmetry `[[0, 1, 2, 3]]` was only doing an `np.roll` of the sublattice indices, instead of permuting them. That is, we were producing `[0, 1, 2, 3]`, `[1, 2, 3, 0]`, `[2, 3, 0, 1]`, and `[3, 0, 1, 2]`, but missing the cases where the relative order changed like `[1, 0, 2, 3]` or `[0, 1, 3, 2]`. 

By supporting the ability to have non-specified sublattices to be fixed (e.g. in the case of an unspecified vacancy sublattice), we are trading off the ability to error check that all the sublattice indices are accounted for exactly once. A possible alternative is to force all sublattice indices to be given in symmetry, such as `[[0, 1, 2, 3], [4], 5]`, where the first two sets of sublattices are interchangeable, while sublattice index 5 is fixed. In practice, this is probably confusing or cumbersome for a corner case of having isolated sublattices that are not interchangeable.

I had a bear of a time figuring out the correct steps to do the permutations and products in, so I tried to comment extensively. May it be a long time before anyone has to read or modify this code again.