### PR TITLE
ENH/MAINT: Refactor residual/likelihood functions

### DIFF
--- a/docs/api/espei.error_functions.rst
+++ b/docs/api/espei.error_functions.rst
@@ -36,6 +36,14 @@ espei.error\_functions.non\_equilibrium\_thermochemical\_error module
    :undoc-members:
    :show-inheritance:
 
+espei.error\_functions.residual\_base module
+--------------------------------------------
+
+.. automodule:: espei.error_functions.residual_base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 espei.error\_functions.zpf\_error module
 ----------------------------------------
 

--- a/docs/api/espei.rst
+++ b/docs/api/espei.rst
@@ -30,14 +30,6 @@ espei.citing module
    :undoc-members:
    :show-inheritance:
 
-espei.constants module
-----------------------
-
-.. automodule:: espei.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 espei.core\_utils module
 ------------------------
 
@@ -138,6 +130,14 @@ espei.sublattice\_tools module
 ------------------------------
 
 .. automodule:: espei.sublattice_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+espei.typing module
+-------------------
+
+.. automodule:: espei.typing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/espei.rst
+++ b/docs/api/espei.rst
@@ -30,6 +30,14 @@ espei.citing module
    :undoc-members:
    :show-inheritance:
 
+espei.constants module
+----------------------
+
+.. automodule:: espei.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 espei.core\_utils module
 ------------------------
 
@@ -74,6 +82,14 @@ espei.paramselect module
 ------------------------
 
 .. automodule:: espei.paramselect
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+espei.phase\_models module
+--------------------------
+
+.. automodule:: espei.phase_models
    :members:
    :undoc-members:
    :show-inheritance:

--- a/espei/constants.py
+++ b/espei/constants.py
@@ -1,0 +1,5 @@
+from typing import List, NewType
+
+ComponentName = NewType("ComponentName", str)
+PhaseName = NewType("PhaseName", str)
+SymbolName = NewType("SymbolName", str)

--- a/espei/constants.py
+++ b/espei/constants.py
@@ -1,5 +1,0 @@
-from typing import List, NewType
-
-ComponentName = NewType("ComponentName", str)
-PhaseName = NewType("PhaseName", str)
-SymbolName = NewType("SymbolName", str)

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -216,6 +216,7 @@ class ActivityResidual(ResidualFunction):
         }
 
     def get_residuals(self, parameters: npt.ArrayLike) -> Tuple[List[float], List[float]]:
+        parameters = {param_name: param for param_name, param in zip(self._symbols_to_fit, parameters.tolist())}
         residuals, weights = calculate_activity_residuals(parameters=parameters, **self._activity_likelihood_kwargs)
         return residuals, weights
 

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -21,7 +21,7 @@ from scipy.stats import norm
 
 from espei.core_utils import ravel_conditions
 from espei.error_functions.residual_base import ResidualFunction, residual_function_registry
-from espei.phase_models import PhaseModels
+from espei.phase_models import PhaseModelSpecification
 from espei.typing import SymbolName
 from espei.utils import database_symbols_to_fit, PickleableTinyDB
 
@@ -199,7 +199,7 @@ class ActivityResidual(ResidualFunction):
         self,
         database: Database,
         datasets: PickleableTinyDB,
-        phase_models: Union[PhaseModels, None],
+        phase_models: Union[PhaseModelSpecification, None],
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -9,7 +9,7 @@ reference state that could be used for equilibrium chemical potentials.
 """
 
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -54,29 +54,83 @@ def target_chempots_from_activity(component, target_activity, temperatures, refe
     return v.R * temperatures * np.log(target_activity) + ref_chempot
 
 
-def chempot_error(sample_chempots, target_chempots, std_dev=10.0):
+# TODO: roll this function into ActivityResidual
+def calculate_activity_residuals(dbf, comps, phases, datasets, parameters=None, phase_models=None, callables=None, data_weight=1.0) -> Tuple[List[float], List[float]]:
     """
-    Return the sum of square error from chemical potentials
+    Notes
+    -----
+    General procedure:
+    1. Get the datasets
+    2. For each dataset
 
-    sample_chempots : numpy.ndarray
-        Calculated chemical potentials
-    target_activity : numpy.ndarray
-        Chemical potentials to target
-    std_dev : float
-        Standard deviation of activity measurements in J/mol. Corresponds to the
-        standard deviation of differences in chemical potential in typical
-        measurements of activity.
-
-    Returns
-    -------
-    float
-        Error due to chemical potentials
+        a. Calculate reference state equilibrium
+        b. Calculate current chemical potentials
+        c. Find the target chemical potentials
+        d. Calculate error due to chemical potentials
     """
-    # coerce the chemical potentials to float64s, fixes an issue where SymPy NaNs don't work
-    return norm(loc=0, scale=std_dev).logpdf(np.array(target_chempots - sample_chempots, dtype=np.float64))
+    std_dev = 500  # J/mol
+
+    if parameters is None:
+        parameters = {}
+
+    activity_datasets = datasets.search(
+        (tinydb.where('output').test(lambda x: 'ACR' in x)) &
+        (tinydb.where('components').test(lambda x: set(x).issubset(comps))))
+
+    residuals = []
+    weights = []
+    for ds in activity_datasets:
+        acr_component = ds['output'].split('_')[1]  # the component of interest
+        # calculate the reference state equilibrium
+        ref = ds['reference_state']
+        # data_comps and data_phases ensures that we only do calculations on
+        # the subsystem of the system defining the data.
+        data_comps = ds['components']
+        data_phases = filter_phases(dbf, unpack_components(dbf, data_comps), candidate_phases=phases)
+        ref_conditions = {_map_coord_to_variable(coord): val for coord, val in ref['conditions'].items()}
+        ref_result = equilibrium(dbf, data_comps, ref['phases'], ref_conditions,
+                                 model=phase_models, parameters=parameters,
+                                 callables=callables)
+
+        # calculate current chemical potentials
+        # get the conditions
+        conditions = {}
+        # first make sure the conditions are paired
+        # only get the compositions, P and T are special cased
+        conds_list = [(cond, value) for cond, value in ds['conditions'].items() if cond not in ('P', 'T')]
+        # ravel the conditions
+        # we will ravel each composition individually, since they all must have the same shape
+        dataset_computed_chempots = []
+        dataset_weights = []
+        for comp_name, comp_x in conds_list:
+            P, T, X = ravel_conditions(ds['values'], ds['conditions']['P'], ds['conditions']['T'], comp_x)
+            conditions[v.P] = P
+            conditions[v.T] = T
+            conditions[_map_coord_to_variable(comp_name)] = X
+        # do the calculations
+        # we cannot currently turn broadcasting off, so we have to do equilibrium one by one
+        # invert the conditions dicts to make a list of condition dicts rather than a condition dict of lists
+        # assume now that the ravelled conditions all have the same size
+        conditions_list = [{c: conditions[c][i] for c in conditions.keys()} for i in range(len(conditions[v.T]))]
+        for conds in conditions_list:
+            sample_eq_res = equilibrium(dbf, data_comps, data_phases, conds,
+                                        model=phase_models, parameters=parameters,
+                                        callables=callables)
+            dataset_computed_chempots.append(float(sample_eq_res.MU.sel(component=acr_component).values.flatten()[0]))
+            dataset_weights.append(std_dev / data_weight / ds.get("weight", 1.0))
+
+        # calculate target chempots
+        dataset_activities = np.array(ds['values']).flatten()
+        dataset_target_chempots = target_chempots_from_activity(acr_component, dataset_activities, conditions[v.T], ref_result)
+        dataset_residuals = (np.asarray(dataset_computed_chempots) - np.asarray(dataset_target_chempots, dtype=float)).tolist()
+        _log.debug('Data: %s, chemical potential difference: %s, reference: %s', dataset_activities, dataset_residuals, ds["reference"])
+        residuals.extend(dataset_residuals)
+        weights.extend(dataset_weights)
+    return residuals, weights
 
 
-def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phase_models=None, callables=None, data_weight=1.0):
+# TODO: roll this function into ActivityResidual
+def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phase_models=None, callables=None, data_weight=1.0) -> float:
     """
     Return the sum of square error from activity data
 
@@ -104,97 +158,17 @@ def calculate_activity_error(dbf, comps, phases, datasets, parameters=None, phas
     Returns
     -------
     float
-        A single float of the sum of square errors
+        A single float of the likelihood
 
-    Notes
-    -----
-    General procedure:
-    1. Get the datasets
-    2. For each dataset
-
-        a. Calculate reference state equilibrium
-        b. Calculate current chemical potentials
-        c. Find the target chemical potentials
-        d. Calculate error due to chemical potentials
 
     """
-    std_dev = 500  # J/mol
-
-    if parameters is None:
-        parameters = {}
-
-    activity_datasets = datasets.search(
-        (tinydb.where('output').test(lambda x: 'ACR' in x)) &
-        (tinydb.where('components').test(lambda x: set(x).issubset(comps))))
-
-    error = 0
-    if len(activity_datasets) == 0:
-        return error
-
-    data_target_chempots = []
-    computed_chempots = []
-    weights = []
-    for ds in activity_datasets:
-        acr_component = ds['output'].split('_')[1]  # the component of interest
-        # calculate the reference state equilibrium
-        ref = ds['reference_state']
-        # data_comps and data_phases ensures that we only do calculations on
-        # the subsystem of the system defining the data.
-        data_comps = ds['components']
-        data_phases = filter_phases(dbf, unpack_components(dbf, data_comps), candidate_phases=phases)
-        ref_conditions = {_map_coord_to_variable(coord): val for coord, val in ref['conditions'].items()}
-        ref_result = equilibrium(dbf, data_comps, ref['phases'], ref_conditions,
-                                 model=phase_models, parameters=parameters,
-                                 callables=callables)
-
-        # calculate current chemical potentials
-        # get the conditions
-        conditions = {}
-        # first make sure the conditions are paired
-        # only get the compositions, P and T are special cased
-        conds_list = [(cond, value) for cond, value in ds['conditions'].items() if cond not in ('P', 'T')]
-        # ravel the conditions
-        # we will ravel each composition individually, since they all must have the same shape
-        for comp_name, comp_x in conds_list:
-            P, T, X = ravel_conditions(ds['values'], ds['conditions']['P'], ds['conditions']['T'], comp_x)
-            conditions[v.P] = P
-            conditions[v.T] = T
-            conditions[_map_coord_to_variable(comp_name)] = X
-        # do the calculations
-        # we cannot currently turn broadcasting off, so we have to do equilibrium one by one
-        # invert the conditions dicts to make a list of condition dicts rather than a condition dict of lists
-        # assume now that the ravelled conditions all have the same size
-        conditions_list = [{c: conditions[c][i] for c in conditions.keys()} for i in range(len(conditions[v.T]))]
-        current_chempots = []
-        for conds in conditions_list:
-            sample_eq_res = equilibrium(dbf, data_comps, data_phases, conds,
-                                        model=phase_models, parameters=parameters,
-                                        callables=callables)
-            current_chempots.append(sample_eq_res.MU.sel(component=acr_component).values.flatten()[0])
-            computed_chempots.append(float(sample_eq_res.MU.sel(component=acr_component).values.flatten()[0]))
-            weights.append(std_dev / data_weight / ds.get("weight", 1.0))
-        current_chempots = np.array(current_chempots)
-
-        # calculate target chempots
-        samples = np.array(ds['values']).flatten()
-        target_chempots = target_chempots_from_activity(acr_component, samples, conditions[v.T], ref_result)
-        data_target_chempots.extend(np.asarray(target_chempots, dtype=float).tolist())
-        # calculate the error
-        weight = ds.get('weight', 1.0)
-        pe = chempot_error(current_chempots, target_chempots, std_dev=std_dev/data_weight/weight)
-        error += np.sum(pe)
-        _log.debug('Data: %s, chemical potential difference: %s, probability: %s, reference: %s', samples, current_chempots-target_chempots, pe, ds["reference"])
-
-    # TODO: write a test for this
-    if np.any(np.isnan(np.array([error], dtype=np.float64))):  # must coerce sympy.core.numbers.Float to float64
-        return -np.inf
-
-    assert len(data_target_chempots) == len(computed_chempots)
-    assert len(data_target_chempots) == len(weights)
-    residuals = np.asarray(data_target_chempots) - np.asarray(computed_chempots).tolist()
-
+    residuals, weights = calculate_activity_residuals(dbf, comps, phases, datasets, parameters=None, phase_models=None, callables=None, data_weight=1.0)
     likelihood = np.sum(norm(0, scale=weights).logpdf(residuals))
-    assert np.isclose(likelihood, error)
+    if np.isnan(likelihood):
+        # TODO: revisit this case and evaluate whether it is resonable for NaN
+        # to show up here. When this comment was written, the test
+        # test_subsystem_activity_probability would trigger a NaN.
+        return -np.inf
     return likelihood
 
 
@@ -241,9 +215,9 @@ class ActivityResidual(ResidualFunction):
             "data_weight": self.weight,
         }
 
-    def get_residual(self, parameters: npt.ArrayLike) -> float:
-        # TODO: implement via refactoring calculate_activity_error
-        raise NotImplementedError("Getting residual for activity data not implemented.")
+    def get_residuals(self, parameters: npt.ArrayLike) -> Tuple[List[float], List[float]]:
+        residuals, weights = calculate_activity_residuals(parameters=parameters, **self._activity_likelihood_kwargs)
+        return residuals, weights
 
     def get_likelihood(self, parameters: npt.NDArray) -> float:
         parameters = {param_name: param for param_name, param in zip(self._symbols_to_fit, parameters.tolist())}

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -19,10 +19,10 @@ from pycalphad.plot.eqplot import _map_coord_to_variable
 from pycalphad.core.utils import filter_phases, unpack_components
 from scipy.stats import norm
 
-from espei.constants import SymbolName
 from espei.core_utils import ravel_conditions
 from espei.error_functions.residual_base import ResidualFunction, residual_function_registry
 from espei.phase_models import PhaseModels
+from espei.typing import SymbolName
 from espei.utils import database_symbols_to_fit, PickleableTinyDB
 
 _log = logging.getLogger(__name__)

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -77,11 +77,6 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
         eq_callables = None
     t2 = time.time()
     _log.trace('Finished building phase models (%0.2fs)', t2-t1)
-    _log.trace('Getting equilibrium thermochemical data (this may take some time)')
-    t1 = time.time()
-    eq_thermochemical_data = get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, model=model_dict, parameters=parameters, data_weight_dict=data_weights)
-    t2 = time.time()
-    _log.trace('Finished getting equilibrium thermochemical data (%0.2fs)', t2-t1)
     residual_objs = []
     for residual_func_class in residual_function_registry.get_registered_residual_functions():
         _log.trace('Getting residual object for %s', residual_func_class.__qualname__)
@@ -97,7 +92,6 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
     error_context = {
         'symbols_to_fit': symbols_to_fit,
         "residual_objs": residual_objs,
-        'equilibrium_thermochemical_kwargs': {'eq_thermochemical_data': eq_thermochemical_data,},
         'activity_kwargs': {
             'dbf': dbf, 'comps': comps, 'phases': phases, 'datasets': datasets,
             'phase_models': models, 'callables': eq_callables,

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -6,6 +6,7 @@ import time
 
 import symengine
 
+from espei.phase_models import PhaseModelSpecification
 from espei.utils import database_symbols_to_fit
 from espei.error_functions.residual_base import residual_function_registry
 
@@ -26,6 +27,9 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
         List of symbols in the Database that will be fit. If None (default) are
         passed, then all parameters prefixed with `VV` followed by a number,
         e.g. VV0001 will be fit.
+    phase_models : Optional[Dict[str, Any]]
+        Phase model dictionary that will be converted to PhaseModelSpecification
+        if it is provided.
 
     Returns
     -------
@@ -36,6 +40,8 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
     back to the original database, the dbf.symbols.update method should be used.
     """
     data_weights = data_weights if data_weights is not None else {}
+    if phase_models is not None:
+        phase_models = PhaseModelSpecification(**phase_models)
 
     # Copy the database because we replace Piecewise symbols and want to preserve the original database
     dbf = copy.deepcopy(dbf)

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -88,7 +88,7 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
     _log.trace('Finished getting equilibrium thermochemical data (%0.2fs)', t2-t1)
     _log.trace('Getting ZPF residual object (this may take some time)')
     t1 = time.time()
-    zpf_residual = ZPFResidual(dbf, datasets, phase_models, symbols_to_fit, data_weights.get('ZPF', 1.0))
+    zpf_residual = ZPFResidual(dbf, datasets, phase_models, symbols_to_fit, data_weights)
     t2 = time.time()
     _log.trace('Finished getting ZPF residual object (%0.2fs)', t2-t1)
 

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -77,13 +77,6 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
         eq_callables = None
     t2 = time.time()
     _log.trace('Finished building phase models (%0.2fs)', t2-t1)
-    _log.trace('Getting non-equilibrium thermochemical data (this may take some time)')
-    t1 = time.time()
-    thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets, model=model_dict, weight_dict=data_weights, symbols_to_fit=symbols_to_fit)
-
-    # fixed_config_residual = ZPFResidual(dbf, datasets, phase_models, symbols_to_fit, data_weights.get('ZPF', 1.0))
-    t2 = time.time()
-    _log.trace('Finished getting non-equilibrium thermochemical data (%0.2fs)', t2-t1)
     _log.trace('Getting equilibrium thermochemical data (this may take some time)')
     t1 = time.time()
     eq_thermochemical_data = get_equilibrium_thermochemical_data(dbf, comps, phases, datasets, model=model_dict, parameters=parameters, data_weight_dict=data_weights)
@@ -104,12 +97,7 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
     error_context = {
         'symbols_to_fit': symbols_to_fit,
         "residual_objs": residual_objs,
-        'equilibrium_thermochemical_kwargs': {
-            'eq_thermochemical_data': eq_thermochemical_data,
-        },
-        'thermochemical_kwargs': {
-            'thermochemical_data': thermochemical_data,
-        },
+        'equilibrium_thermochemical_kwargs': {'eq_thermochemical_data': eq_thermochemical_data,},
         'activity_kwargs': {
             'dbf': dbf, 'comps': comps, 'phases': phases, 'datasets': datasets,
             'phase_models': models, 'callables': eq_callables,

--- a/espei/error_functions/context.py
+++ b/espei/error_functions/context.py
@@ -2,14 +2,12 @@
 
 import logging
 import copy
+import time
+
 import symengine
-from pycalphad import variables as v
-from pycalphad.codegen.callables import build_callables
-from pycalphad.core.utils import instantiate_models, filter_phases, unpack_components
-from espei.error_functions import get_thermochemical_data, get_equilibrium_thermochemical_data
-from espei.utils import database_symbols_to_fit, get_model_dict
+
+from espei.utils import database_symbols_to_fit
 from espei.error_functions.residual_base import residual_function_registry
-from espei.error_functions.zpf_error import ZPFResidual
 
 _log = logging.getLogger(__name__)
 
@@ -37,65 +35,36 @@ def setup_context(dbf, datasets, symbols_to_fit=None, data_weights=None, phase_m
     A copy of the Database is made and used in the context. To commit changes
     back to the original database, the dbf.symbols.update method should be used.
     """
+    data_weights = data_weights if data_weights is not None else {}
+
+    # Copy the database because we replace Piecewise symbols and want to preserve the original database
     dbf = copy.deepcopy(dbf)
-    if phase_models is not None:
-        comps = sorted(phase_models['components'])
-    else:
-        comps = sorted([sp for sp in dbf.elements])
     if symbols_to_fit is None:
         symbols_to_fit = database_symbols_to_fit(dbf)
     else:
         symbols_to_fit = sorted(symbols_to_fit)
-    data_weights = data_weights if data_weights is not None else {}
-
     if len(symbols_to_fit) == 0:
-        raise ValueError('No degrees of freedom. Database must contain symbols starting with \'V\' or \'VV\', followed by a number.')
+        raise ValueError("No degrees of freedom. Database must contain symbols starting with 'V' or 'VV', followed by a number.")
     else:
-        _log.info('Fitting %s degrees of freedom.', len(symbols_to_fit))
-
+        _log.info("Fitting %s degrees of freedom.", len(symbols_to_fit))
     for x in symbols_to_fit:
         if isinstance(dbf.symbols[x], symengine.Piecewise):
-            _log.debug('Replacing %s in database', x)
+            _log.debug("Replacing %s in database", x)
             dbf.symbols[x] = dbf.symbols[x].args[0]
 
-    # construct the models for each phase, substituting in the SymEngine symbol to fit.
-    if phase_models is not None:
-        model_dict = get_model_dict(phase_models)
-    else:
-        model_dict = {}
-    _log.trace('Building phase models (this may take some time)')
-    import time
-    t1 = time.time()
-    phases = sorted(filter_phases(dbf, unpack_components(dbf, comps), dbf.phases.keys()))
-    parameters = dict(zip(symbols_to_fit, [0]*len(symbols_to_fit)))
-    models = instantiate_models(dbf, comps, phases, model=model_dict, parameters=parameters)
-    if make_callables:
-        eq_callables = build_callables(dbf, comps, phases, models, parameter_symbols=symbols_to_fit,
-                            output='GM', build_gradients=True, build_hessians=True,
-                            additional_statevars={v.N, v.P, v.T})
-    else:
-        eq_callables = None
-    t2 = time.time()
-    _log.trace('Finished building phase models (%0.2fs)', t2-t1)
     residual_objs = []
     for residual_func_class in residual_function_registry.get_registered_residual_functions():
-        _log.trace('Getting residual object for %s', residual_func_class.__qualname__)
+        _log.trace("Getting residual object for %s", residual_func_class.__qualname__)
         t1 = time.time()
         residual_obj = residual_func_class(dbf, datasets, phase_models, symbols_to_fit, data_weights)
         residual_objs.append(residual_obj)
         t2 = time.time()
-        _log.trace('Finished getting residual object for %s in %0.2f s', residual_func_class.__qualname__, t2-t1)
-
+        _log.trace("Finished getting residual object for %s in %0.2f s", residual_func_class.__qualname__, t2-t1)
 
     # context for the log probability function
     # for all cases, parameters argument addressed in MCMC loop
     error_context = {
-        'symbols_to_fit': symbols_to_fit,
+        "symbols_to_fit": symbols_to_fit,
         "residual_objs": residual_objs,
-        'activity_kwargs': {
-            'dbf': dbf, 'comps': comps, 'phases': phases, 'datasets': datasets,
-            'phase_models': models, 'callables': eq_callables,
-            'data_weight': data_weights.get('ACR', 1.0),
-        },
     }
     return error_context

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -312,7 +312,6 @@ class EquilibriumPropertyResidual(ResidualFunction):
         self.property_data = get_equilibrium_thermochemical_data(database, comps, phases, datasets, model_dict, parameters, data_weight_dict=self.weight)
 
     def get_residuals(self, parameters: npt.ArrayLike) -> Tuple[List[float], List[float]]:
-        # TODO: residual probably not meaningful because the data have different scales
         residuals = []
         weights = []
         for data in self.property_data:

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -282,9 +282,6 @@ def calculate_equilibrium_thermochemical_probability(eq_thermochemical_data: Seq
     return np.sum(probs)
 
 
-# TODO: refactor into one instance per property at the level of this object? We
-#       could approximate that kind of behavior by limiting the datasets to a
-#       subset of only one property at a time.
 class EquilibriumPropertyResidual(ResidualFunction):
     def __init__(
         self,

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -19,7 +19,7 @@ from pycalphad.core.utils import instantiate_models, filter_phases, extract_para
 from pycalphad.core.phase_rec import PhaseRecord
 
 from espei.error_functions.residual_base import ResidualFunction, residual_function_registry
-from espei.phase_models import PhaseModels
+from espei.phase_models import PhaseModelSpecification
 from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters
 from espei.typing import SymbolName
 from espei.utils import PickleableTinyDB, database_symbols_to_fit
@@ -290,7 +290,7 @@ class EquilibriumPropertyResidual(ResidualFunction):
         self,
         database: Database,
         datasets: PickleableTinyDB,
-        phase_models: Union[PhaseModels, None],
+        phase_models: Union[PhaseModelSpecification, None],
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -18,10 +18,10 @@ from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.utils import instantiate_models, filter_phases, extract_parameters, unpack_components, unpack_condition
 from pycalphad.core.phase_rec import PhaseRecord
 
-from espei.constants import SymbolName
 from espei.error_functions.residual_base import ResidualFunction, residual_function_registry
 from espei.phase_models import PhaseModels
 from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters
+from espei.typing import SymbolName
 from espei.utils import PickleableTinyDB, database_symbols_to_fit
 
 _log = logging.getLogger(__name__)

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -314,15 +314,15 @@ class EquilibriumPropertyResidual(ResidualFunction):
         parameters = dict(zip(symbols_to_fit, [0]*len(symbols_to_fit)))
         self.property_data = get_equilibrium_thermochemical_data(database, comps, phases, datasets, model_dict, parameters, data_weight_dict=self.weight)
 
-    def get_residual(self, parameters: npt.ArrayLike) -> float:
+    def get_residuals(self, parameters: npt.ArrayLike) -> Tuple[List[float], List[float]]:
         # TODO: residual probably not meaningful because the data have different scales
-        all_differences = []
+        residuals = []
+        weights = []
         for data in self.property_data:
-            differences, _weights = calc_prop_differences(data, parameters)
-            all_differences.append(differences)
-        differences = np.concatenate(all_differences, axis=0)
-        residual = np.sum(np.abs(differences))
-        return residual
+            dataset_residuals, dataset_weights = calc_prop_differences(data, parameters)
+            residuals.extend(dataset_residuals.tolist())
+            weights.extend(dataset_weights.tolist())
+        return residuals, weights
 
     def get_likelihood(self, parameters) -> float:
         likelihood = calculate_equilibrium_thermochemical_probability(self.property_data, parameters)

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -17,11 +17,11 @@ from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.utils import unpack_components, get_pure_elements, filter_phases
 
 from espei.datasets import Dataset
-from espei.constants import SymbolName
 from espei.core_utils import ravel_conditions, get_prop_data, filter_temperatures
 from espei.phase_models import PhaseModels
 from espei.shadow_functions import calculate_, update_phase_record_parameters
 from espei.sublattice_tools import canonicalize, recursive_tuplify, tuplify
+from espei.typing import SymbolName
 from espei.utils import database_symbols_to_fit, PickleableTinyDB
 from .residual_base import ResidualFunction, residual_function_registry
 

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -323,9 +323,6 @@ def calculate_non_equilibrium_thermochemical_probability(thermochemical_data: Li
     return prob_error
 
 
-# TODO: refactor into one instance per property at the level of this object? We
-#       could approximate that kind of behavior by limiting the datasets to a
-#       subset of only one property at a time.
 class FixedConfigurationPropertyResidual(ResidualFunction):
     def __init__(
         self,

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -351,7 +351,6 @@ class FixedConfigurationPropertyResidual(ResidualFunction):
         self.thermochemical_data = get_thermochemical_data(database, comps, phases, datasets, model_dict, weight_dict=self.weight, symbols_to_fit=symbols_to_fit)
 
     def get_residuals(self, parameters: npt.ArrayLike) -> Tuple[List[float], List[float]]:
-        # TODO: residual probably not meaningful because the data have different scales
         residuals = []
         weights = []
         for data in self.thermochemical_data:

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -18,7 +18,7 @@ from pycalphad.core.utils import unpack_components, get_pure_elements, filter_ph
 
 from espei.datasets import Dataset
 from espei.core_utils import ravel_conditions, get_prop_data, filter_temperatures
-from espei.phase_models import PhaseModels
+from espei.phase_models import PhaseModelSpecification
 from espei.shadow_functions import calculate_, update_phase_record_parameters
 from espei.sublattice_tools import canonicalize, recursive_tuplify, tuplify
 from espei.typing import SymbolName
@@ -331,7 +331,7 @@ class FixedConfigurationPropertyResidual(ResidualFunction):
         self,
         database: Database,
         datasets: PickleableTinyDB,
-        phase_models: Union[PhaseModels, None],
+        phase_models: Union[PhaseModelSpecification, None],
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, List, Optional, Protocol, Union
 
 from numpy.typing import ArrayLike
 
@@ -41,7 +41,7 @@ class ResidualFunction(Protocol):
 
     Attributes
     ----------
-    weight : float
+    weight : Optional[Union[float, Dict[str, float]]]
 
     """
 
@@ -50,8 +50,8 @@ class ResidualFunction(Protocol):
         database: Database,
         datasets: PickleableTinyDB,
         phase_models: PhaseModels,
-        symbols_to_fit: Optional[List[SymbolName]] = None,
-        weight: Optional[float] = 1.0,
+        symbols_to_fit: Optional[List[SymbolName]],
+        weight: Optional[Union[float, Dict[str, float]]],
         ):
         ...
 

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -4,7 +4,7 @@ from numpy.typing import ArrayLike
 
 from pycalphad import Database
 
-from espei.phase_models import PhaseModels
+from espei.phase_models import PhaseModelSpecification
 from espei.typing import SymbolName
 from espei.utils import PickleableTinyDB
 
@@ -49,7 +49,7 @@ class ResidualFunction(Protocol):
         self,
         database: Database,
         datasets: PickleableTinyDB,
-        phase_models: PhaseModels,
+        phase_models: PhaseModelSpecification,
         symbols_to_fit: Optional[List[SymbolName]],
         weight: Optional[Dict[str, float]],
         ):

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Protocol, Union
+from typing import Dict, List, Optional, Protocol, Type
 
 from numpy.typing import ArrayLike
 
@@ -98,12 +98,12 @@ class ResidualFunction(Protocol):
 
 class ResidualRegistry():
     def __init__(self) -> None:
-        self._registered_residual_functions = []
+        self._registered_residual_functions: Type[ResidualFunction] = []
 
-    def get_registered_residual_functions(self) -> List[ResidualFunction]:
+    def get_registered_residual_functions(self) -> List[Type[ResidualFunction]]:
         return self._registered_residual_functions
 
-    def register(self, residual_function):
+    def register(self, residual_function: Type[ResidualFunction]):
         # Don't allow duplicates
         if residual_function not in self._registered_residual_functions:
             self._registered_residual_functions.append(residual_function)

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -1,0 +1,96 @@
+from typing import Dict, List, Optional, Protocol
+
+from numpy.typing import ArrayLike
+
+from pycalphad import Database
+
+from espei.constants import SymbolName
+from espei.phase_models import PhaseModels
+from espei.utils import PickleableTinyDB
+
+
+class ResidualFunction(Protocol):
+    """
+    Protocol class for computing the error (residual) between data and a model
+    prediction given a set of parameters.
+
+    Classes that implement this protocol typically will concerned with
+    implementing a residual/likelihood function for a certain type of data. The
+    protocol is intentitionally left to be simple to implement while enabling
+    flexibility to implement additional methods and attributes for performance
+    and debugging purposes.
+
+    Parameters
+    ----------
+    database : Database
+    datasets : PickleableTinyDB
+        The candidate datasets for the a contribution. Usually the datasets
+        are a superset (in components, phases, data types, etc.) of the actual
+        data used to compute the residual for any particular contribution.
+    phase_models : PhaseModels
+        Defines the active set of components that should be fit and any
+        user-provided overrides to the PyCalphad Model class for each phase.
+    symbols_to_fit : Optional[List[SymbolName]]
+        User-provided symbols to fit. By default, the symbols to fit should be
+        set by ``espei.utils.database_symbols_to_fit``.
+    weight : Optional[float]
+        When computing the likelihood, this should be used to modify the
+        probability distribution. Higher weights should correspond to narrower
+        probability distributions, but it's exact use will depend on the
+        particular probability distribution.
+
+    Attributes
+    ----------
+    weight : float
+
+    """
+
+    def __init__(
+        self,
+        database: Database,
+        datasets: PickleableTinyDB,
+        phase_models: PhaseModels,
+        symbols_to_fit: Optional[List[SymbolName]] = None,
+        weight: Optional[float] = 1.0,
+        ):
+        ...
+
+    def get_residual(self, parameters: ArrayLike) -> float:
+        """
+        Return the residual comparing the selected data to the set of parameters.
+
+        The residual is zero if the database predictions under the given
+        parameters agrees with the data exactly.
+
+        Parameters
+        ----------
+        parameters : ArrayLike
+            1D parameter vector. The size of the parameters array should match
+            the number of fitting symbols used to build the models. This is
+            _not_ checked.
+
+        Returns
+        -------
+        float
+            Value of the residual for the given set of parameters
+
+        """
+        ...
+
+    def get_likelihood(self, parameters) -> float:
+        """
+        Return log-likelihood for the set of parameters.
+
+        Parameters
+        ----------
+        parameters : ArrayLike
+            1D parameter vector. The size of the parameters array should match
+            the number of fitting symbols used to build the models. This is
+            _not_ checked.
+
+        Returns
+        -------
+        float
+            Value of log-likelihood for the given set of parameters
+        """
+        ...

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -4,8 +4,8 @@ from numpy.typing import ArrayLike
 
 from pycalphad import Database
 
-from espei.constants import SymbolName
 from espei.phase_models import PhaseModels
+from espei.typing import SymbolName
 from espei.utils import PickleableTinyDB
 
 

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -51,7 +51,7 @@ class ResidualFunction(Protocol):
         datasets: PickleableTinyDB,
         phase_models: PhaseModels,
         symbols_to_fit: Optional[List[SymbolName]],
-        weight: Optional[Union[float, Dict[str, float]]],
+        weight: Optional[Dict[str, float]],
         ):
         ...
 
@@ -94,3 +94,18 @@ class ResidualFunction(Protocol):
             Value of log-likelihood for the given set of parameters
         """
         ...
+
+
+class ResidualRegistry():
+    def __init__(self) -> None:
+        self._registered_residual_functions = []
+
+    def get_registered_residual_functions(self) -> List[ResidualFunction]:
+        return self._registered_residual_functions
+
+    def register(self, residual_function):
+        # Don't allow duplicates
+        if residual_function not in self._registered_residual_functions:
+            self._registered_residual_functions.append(residual_function)
+
+residual_function_registry = ResidualRegistry()

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Protocol, Type
+from typing import Dict, List, Optional, Protocol, Tuple, Type
 
 from numpy.typing import ArrayLike
 
@@ -55,7 +55,7 @@ class ResidualFunction(Protocol):
         ):
         ...
 
-    def get_residual(self, parameters: ArrayLike) -> float:
+    def get_residuals(self, parameters: ArrayLike) -> Tuple[List[float], List[float]]:
         """
         Return the residual comparing the selected data to the set of parameters.
 
@@ -71,8 +71,8 @@ class ResidualFunction(Protocol):
 
         Returns
         -------
-        float
-            Value of the residual for the given set of parameters
+        Tuple[List[float], List[float]]
+            Tuple of (residuals, weights), which must obey len(residuals) == len(weights)
 
         """
         ...

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -21,20 +21,19 @@ from typing import Sequence, Dict, Any, Union, List, Tuple, Type, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
-from scipy.stats import norm
-import tinydb
-
 from pycalphad import Database, Model, variables as v
 from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.utils import instantiate_models, filter_phases, unpack_components
 from pycalphad.core.phase_rec import PhaseRecord
-from espei.utils import PickleableTinyDB, database_symbols_to_fit
-from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters, constrained_equilibrium
 from pycalphad.core.calculate import _sample_phase_constitution
 from pycalphad.core.utils import point_sample
+from scipy.stats import norm
+import tinydb
 
 from espei.phase_models import PhaseModels
-from espei.constants import SymbolName
+from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters, constrained_equilibrium
+from espei.typing import SymbolName
+from espei.utils import PickleableTinyDB, database_symbols_to_fit
 from .residual_base import ResidualFunction, residual_function_registry
 
 _log = logging.getLogger(__name__)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -35,7 +35,7 @@ from pycalphad.core.utils import point_sample
 
 from espei.phase_models import PhaseModels
 from espei.constants import SymbolName
-from .residual_base import ResidualFunction
+from .residual_base import ResidualFunction, residual_function_registry
 
 _log = logging.getLogger(__name__)
 
@@ -468,3 +468,6 @@ class ZPFResidual(ResidualFunction):
     def get_likelihood(self, parameters) -> float:
         likelihood = calculate_zpf_error(self.zpf_data, parameters, data_weight=self.weight)
         return likelihood
+
+
+residual_function_registry.register(ZPFResidual)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -30,7 +30,7 @@ from pycalphad.core.utils import point_sample
 from scipy.stats import norm
 import tinydb
 
-from espei.phase_models import PhaseModels
+from espei.phase_models import PhaseModelSpecification
 from espei.shadow_functions import equilibrium_, calculate_, no_op_equilibrium_, update_phase_record_parameters, constrained_equilibrium
 from espei.typing import SymbolName
 from espei.utils import PickleableTinyDB, database_symbols_to_fit
@@ -435,7 +435,7 @@ class ZPFResidual(ResidualFunction):
         self,
         database: Database,
         datasets: PickleableTinyDB,
-        phase_models: Union[PhaseModels, None],
+        phase_models: Union[PhaseModelSpecification, None],
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -457,12 +457,12 @@ class ZPFResidual(ResidualFunction):
         parameters = dict(zip(symbols_to_fit, [0]*len(symbols_to_fit)))
         self.zpf_data = get_zpf_data(database, comps, phases, datasets, parameters, model_dict)
 
-    def get_residual(self, parameters: ArrayLike) -> float:
+    def get_residuals(self, parameters: ArrayLike) -> Tuple[List[float], List[float]]:
         driving_forces, weights = calculate_zpf_driving_forces(self.zpf_data, parameters, short_circuit=True)
         # Driving forces and weights are 2D ragged arrays with the shape (len(zpf_data), len(zpf_data['values']))
-        driving_forces = np.concatenate(driving_forces)
-        residual = np.sum(np.abs(driving_forces))
-        return residual
+        residuals = np.concatenate(driving_forces).tolist()
+        weights = np.concatenate(weights).tolist()
+        return residuals, weights
 
     def get_likelihood(self, parameters) -> float:
         likelihood = calculate_zpf_error(self.zpf_data, parameters, data_weight=self.weight)

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -438,10 +438,13 @@ class ZPFResidual(ResidualFunction):
         datasets: PickleableTinyDB,
         phase_models: Union[PhaseModels, None],
         symbols_to_fit: Optional[List[SymbolName]] = None,
-        weight: Optional[float] = 1.0,
+        weight: Optional[Dict[str, float]] = None,
         ):
         super().__init__(database, datasets, phase_models, symbols_to_fit)
-        self.weight = weight
+        if weight is not None:
+            self.weight = weight.get("ZPF", 1.0)
+        else:
+            self.weight = 1.0
         if phase_models is not None:
             comps = sorted(phase_models.components)
             model_dict = phase_models.get_model_dict()

--- a/espei/optimizers/opt_scipy.py
+++ b/espei/optimizers/opt_scipy.py
@@ -31,23 +31,14 @@ class SciPyOptimizer(OptimizerBase):
 
     @staticmethod
     def predict(params, ctx):
-        parameters = {param_name: param for param_name, param in zip(ctx['symbols_to_fit'], params)}
-        activity_kwargs = ctx.get('activity_kwargs')
         starttime = time.time()
-
         lnlike = 0.0
         likelihoods = {}
         for residual_obj in ctx.get("residual_objs", []):
             likelihood = residual_obj.get_likelihood(params)
             likelihoods[type(residual_obj).__name__] = likelihood
             lnlike += likelihood
-
-        if activity_kwargs is not None:
-            actvity_error = calculate_activity_error(parameters=parameters, **activity_kwargs)
-        else:
-            actvity_error = 0
-        total_error = lnlike + actvity_error
         like_str = ". ".join([f"{ky}: {vl:0.3f}" for ky, vl in likelihoods.items()])
-        _log.trace('Likelihood - %0.2fs - Activity: %0.3f. %s. Total: %0.3f.', time.time() - starttime, actvity_error, like_str, total_error)
-        error = np.array(total_error, dtype=np.float64)
+        _log.trace('Likelihood - %0.2fs. %s. Total: %0.3f.', time.time() - starttime, like_str, lnlike)
+        error = np.array(lnlike, dtype=np.float64)
         return error

--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -15,38 +15,6 @@ class ModelMetadata(BaseModel):
 
 
 class PhaseModelSpecification(BaseModel):
-    """
-
-    Examples
-    --------
-    >>> from espei.phase_models import PhaseModelSpecification
-    >>> data = {
-    ...   "components": ["CU", "MG", "VA"],
-    ...   "phases": {
-    ...          "LIQUID" : {
-    ...             "sublattice_model": [["CU", "MG"]],
-    ...             "sublattice_site_ratios": [1],
-    ...             "model": "pycalphad.model.Model"
-    ...          },
-    ...          "FCC_A1": {
-    ...             "sublattice_model": [["CU", "MG"], ["VA"]],
-    ...             "sublattice_site_ratios": [1, 1]
-    ...          }
-    ...     }
-    ... }
-    ...
-    >>> phase_models = PhaseModelSpecification(**data)
-    >>> assert len(phase_models.phases) == 2
-    >>> assert phase_models.phases["LIQUID"].sublattice_model == [["CU", "MG"]]
-    >>> assert phase_models.phases["LIQUID"].sublattice_site_ratios == [1]
-    >>> assert type(phase_models.phases["LIQUID"].model) is type
-    >>> assert phase_models.phases["FCC_A1"].model is None
-    >>> assert "LIQUID" in phase_models.get_model_dict()
-    >>> assert len(phase_models.get_model_dict()) == 1
-    >>> assert phase_models.get_model_dict()["LIQUID"] == phase_models.phases["LIQUID"].model
-    >>> assert phase_models.phases["FCC_A1"].model is None
-
-    """
     components: List[ComponentName]
     phases: Dict[PhaseName, ModelMetadata]
 

--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 from pydantic import BaseModel, PositiveFloat, PyObject
+from pycalphad import Model
 
 from espei.constants import ComponentName, PhaseName
 
@@ -16,3 +17,22 @@ class PhaseModelMetadata(BaseModel):
 class PhaseModels(BaseModel):
     components: List[ComponentName]
     phases: Dict[PhaseName, PhaseModelMetadata]
+
+    # TODO: update type of Model to ModelProtocol if/when available
+    def get_model_dict(self) -> Dict[str, Type[Model]]:
+        """
+        Return a pycalphad-style model dictionary mapping phase names to model classes.
+
+        If a phase's "model" key is not specified, no entry is created. In practice, the
+        behavior of the defaults would be handled by pycalphad.
+
+        Returns
+        -------
+        Any
+
+        """
+        model_dict = {}
+        for phase_name, phase_model_metadata in self.phases.items():
+            if phase_model_metadata.model_class is not None:
+                model_dict[phase_name] = phase_model_metadata.model_class
+        return model_dict

--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Type
 from pydantic import BaseModel, PositiveFloat, PyObject
 from pycalphad import Model
 
-from espei.constants import ComponentName, PhaseName
+from espei.typing import ComponentName, PhaseName
 
 
 # TODO: validate that len(model) == len(coefficients)

--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -7,16 +7,48 @@ from espei.typing import ComponentName, PhaseName
 
 
 # TODO: validate that len(model) == len(coefficients)
-class PhaseModelMetadata(BaseModel):
+class ModelMetadata(BaseModel):
     sublattice_model: List[List[ComponentName]]
-    coefficients: List[PositiveFloat]
+    sublattice_site_ratios: List[PositiveFloat]
     # Fully qualified import path for a Python class that follows the pycalphad.Model API
-    model_class: Optional[PyObject]
+    model: Optional[PyObject]
 
 
-class PhaseModels(BaseModel):
+class PhaseModelSpecification(BaseModel):
+    """
+
+    Examples
+    --------
+    >>> from espei.phase_models import PhaseModelSpecification
+    >>> data = {
+    ...   "components": ["CU", "MG", "VA"],
+    ...   "phases": {
+    ...          "LIQUID" : {
+    ...             "sublattice_model": [["CU", "MG"]],
+    ...             "sublattice_site_ratios": [1],
+    ...             "model": "pycalphad.model.Model"
+    ...          },
+    ...          "FCC_A1": {
+    ...             "sublattice_model": [["CU", "MG"], ["VA"]],
+    ...             "sublattice_site_ratios": [1, 1]
+    ...          }
+    ...     }
+    ... }
+    ...
+    >>> phase_models = PhaseModelSpecification(**data)
+    >>> assert len(phase_models.phases) == 2
+    >>> assert phase_models.phases["LIQUID"].sublattice_model == [["CU", "MG"]]
+    >>> assert phase_models.phases["LIQUID"].sublattice_site_ratios == [1]
+    >>> assert type(phase_models.phases["LIQUID"].model) is type
+    >>> assert phase_models.phases["FCC_A1"].model is None
+    >>> assert "LIQUID" in phase_models.get_model_dict()
+    >>> assert len(phase_models.get_model_dict()) == 1
+    >>> assert phase_models.get_model_dict()["LIQUID"] == phase_models.phases["LIQUID"].model
+    >>> assert phase_models.phases["FCC_A1"].model is None
+
+    """
     components: List[ComponentName]
-    phases: Dict[PhaseName, PhaseModelMetadata]
+    phases: Dict[PhaseName, ModelMetadata]
 
     # TODO: update type of Model to ModelProtocol if/when available
     def get_model_dict(self) -> Dict[str, Type[Model]]:
@@ -33,6 +65,6 @@ class PhaseModels(BaseModel):
         """
         model_dict = {}
         for phase_name, phase_model_metadata in self.phases.items():
-            if phase_model_metadata.model_class is not None:
-                model_dict[phase_name] = phase_model_metadata.model_class
+            if phase_model_metadata.model is not None:
+                model_dict[phase_name] = phase_model_metadata.model
         return model_dict

--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -1,0 +1,18 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, PositiveFloat, PyObject
+
+from espei.constants import ComponentName, PhaseName
+
+
+# TODO: validate that len(model) == len(coefficients)
+class PhaseModelMetadata(BaseModel):
+    sublattice_model: List[List[ComponentName]]
+    coefficients: List[PositiveFloat]
+    # Fully qualified import path for a Python class that follows the pycalphad.Model API
+    model_class: Optional[PyObject]
+
+
+class PhaseModels(BaseModel):
+    components: List[ComponentName]
+    phases: Dict[PhaseName, PhaseModelMetadata]

--- a/espei/typing.py
+++ b/espei/typing.py
@@ -1,0 +1,5 @@
+from typing import List, NewType
+
+ComponentName = NewType("ComponentName", str)
+PhaseName = NewType("PhaseName", str)
+SymbolName = NewType("SymbolName", str)

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -424,3 +424,23 @@ def get_model_dict(phase_models: dict) -> Dict[str, Type[Model]]:
         if qualified_model_class is not None:
             model_dict[phase_name] = import_qualified_object(qualified_model_class)
     return model_dict
+
+
+class ModelTestException(Exception):
+    ...
+
+
+def _raise_model_test_exception(*args, **kwargs):
+    raise ModelTestException()
+
+
+class ErrorModel(Model):
+    """
+    The only purpose of this class is to raise an exception when getting the molar Gibbs energy
+
+    It is used by the tests.
+    """
+    def __init__(self, dbe, comps, phase_name, parameters=None):
+        super().__init__(dbe, comps, phase_name, parameters)
+
+        self.GM = _raise_model_test_exception()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,9 @@ testpaths = [
 ]
 
 [tool.setuptools_scm]
+
+[tool.coverage.run]
+# Only consider coverage for these packages:
+source_pkgs = [
+    "espei"
+]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'matplotlib',
         'numpy>=1.20',
         'pycalphad>=0.10.1',
+        'pydantic',
         'pyyaml',
         'setuptools_scm[toml]>=6.0',
         'scikit-learn>=1.0',

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -54,17 +54,16 @@ def test_lnprob_calculates_single_phase_probability_for_success(datasets_db):
     orig_val = -14.0865
     opt = EmceeOptimizer(dbf)
 
-    thermochemical_data = get_thermochemical_data(dbf, comps, phases, datasets_db, symbols_to_fit=[param])
-    thermochemical_kwargs = {'thermochemical_data': thermochemical_data}
-    res_orig = opt.predict([orig_val], prior_rvs=[rv_zero()], symbols_to_fit=[param], thermochemical_kwargs=thermochemical_kwargs)
+    ctx = setup_context(dbf, datasets_db, symbols_to_fit=[param])
+    res_orig = opt.predict([orig_val], prior_rvs=[rv_zero()], **ctx)
     assert np.isreal(res_orig)
     assert np.isclose(res_orig, -9.119484935312146, rtol=1e-6)
 
-    res_10 = opt.predict([10.0], prior_rvs=[rv_zero()], symbols_to_fit=[param], thermochemical_kwargs=thermochemical_kwargs)
+    res_10 = opt.predict([10.0], prior_rvs=[rv_zero()], **ctx)
     assert np.isreal(res_10)
     assert np.isclose(res_10, -9.143559131626864, rtol=1e-6)
 
-    res_1e5 = opt.predict([1e5], prior_rvs=[rv_zero()], symbols_to_fit=[param], thermochemical_kwargs=thermochemical_kwargs)
+    res_1e5 = opt.predict([1e5], prior_rvs=[rv_zero()], **ctx)
     assert np.isreal(res_1e5)
     assert np.isclose(res_1e5, -1359.1335466316268, rtol=1e-6)
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -68,6 +68,21 @@ def test_lnprob_calculates_single_phase_probability_for_success(datasets_db):
     assert np.isclose(res_1e5, -1359.1335466316268, rtol=1e-6)
 
 
+def test_optimizer_computes_probability_with_activity_data(datasets_db):
+    """EmceeOptimizer correctly computed probability with activity data
+
+    This test is mathematically redundant with test_error_functions.test_activity_error, but aims to test the functionality of using the Optimizer / ResidualFunction API
+    """
+    datasets_db.insert(CU_MG_EXP_ACTIVITY)
+    dbf = Database(CU_MG_TDB)
+    opt = EmceeOptimizer(dbf)
+    # Having no degrees of freedom isn't currently allowed by setup_context
+    # we use VV0000 and the current value in the database
+    ctx = setup_context(dbf, datasets_db, symbols_to_fit=["VV0000"])
+    error = opt.predict(np.array([-32429.6]), **ctx)
+    assert np.isclose(error, -257.41020886970756, rtol=1e-6)
+
+
 def _eq_LinAlgError(*args, **kwargs):
     raise LinAlgError()
 


### PR DESCRIPTION
This PR is a pretty substantial internal refactor and probably needs a close look by anyone modifying or developing new likelihood functions. I tried to only make light changes to existing likelihood functions and implement this new functionality around what already exists. @HUISUN24: this will probably affect #234, but hopefully will make it much simpler and your changes will have to touch many fewer places in the code. @jorgepazsoldanpalma will probably want to look too, but hopefully this doesn't affect you too much.

## Summary

This PR introduces a `ResidualFunction` class to abstract the concept of residual/likelihood functions for different types of data. This allows new residual functions to be defined (both internally and externally) and registered for dynamic use. The `ResidualFunction` class also aims to encapsulate the concept of a likelihood function in terms of what ESPEI can provide as inputs (a database, datasets and related metadata) and outputs via calling conventions, which should make it clearer how to add new likelihood contributions and what functionality needs to be tested.

Other changes include:
- priors can now be optionally provided to the `EmceeOptimizer.predict` method, to better match the API. The default is now the improper zero prior, which is backwards compatible
- introduce an `espei.typing` module that currently holds some type aliases that improve semantics, especially since so many things are simply strings
- introduce [pydantic](https://pydantic-docs.helpmanual.io/) as a dependency to be able to enable parsing of phase models (and, in the future, datasets) into objects. 

## Blocking TODO items

- [x] We need to convert JSON/Dict phase models to PhaseModels object via pydantic with a test, right now there’s no test that phase models can even be passed (the below code doesn’t raise) and no test that a custom model works either
    ```python
        # somewhere in espei.error_functions.context.setup_context
        if phase_models is not None:
            raise ValueError(f"Got phase models, {phase_models}")
    ```
- [x] Add pydantic to the dependencies
- [x] ~Think more about whether to include `ResidualFunction.get_residual` method as part of the API. The `get_residual` method is not tested or used anywhere. My original thought was to use them as a hook to test the residual directly because the residual should be zero for exact solutions, but the likelihood does not have any restrictions if the residual is zero. Since the residual is only well defined for a particular data point, but the `ResidualFunction` may have many data points and describe different types of data, `get_residual` might not be clear as a concept under the current implementation. `get_residual` would make more sense in context of looking at one particular "experiment"/"measurement"/"calculation", but the question is whether or not that is easy enough to expose in the API, since datasets can be 0-, 1-, or 3-dimensional currently and have associated metadata like phase records that are expensive to duplicate.~ `ResidualFunction.get_residuals` (not the plural `residuals`) now returns a tuple of a list of residuals and weights (of equal length). These could conceivably be used by any likelihood function and are meaningfully scaled against each other because we are keeping track of the weights. 
- [x] Remove some of the TODO comments for equilibrium/fixed-configuration property residuals having different objects per property. It makes sense that they should take in _all_ the datasets and pick out the ones they can each handle.
- [x] Some manual testing to investigate regressions that tests don't cover


## Deferred TODO items
- [ ] refactor activity error function to fix any correctness ambiguities and performance issues (ultimately I’d like to see this go away entirely in favor of EquilibriumPropertyResidual, but we need better support for reference states and computing activities directly from equilibrium)
- [ ] revamp testing (with coverage), recipes and code usage to only use these `ResidualFunction` instances 
- [ ] use pydantic for coverting JSON data into Python objects and using those in the residual functions
- [ ] Documentation? Examples?

