### PR TITLE
FIX: Fix isothermal ternary projection dataplots

### DIFF
--- a/espei/plot.py
+++ b/espei/plot.py
@@ -307,10 +307,7 @@ def dataplot(comps, phases, conds, datasets, tielines=True, ax=None, plot_kwargs
                 warnings.warn("'{0}' passed as plotting keyword argument to dataplot, but the alias '{1}' is already set to '{2}'. Use the full version of the keyword argument '{1}' to override the default.".format(aliased_arg, actual_arg, scatter_kwargs.get(actual_arg)))
         scatter_kwargs.update(plot_kwargs)
 
-        # Only T supported
-        if y is not v.T:
-            raise ValueError("Only fixed temperature currently supported for triangular projections")
-
+        # Only fixed T supported for isopotential ternary projections
         eq_dict = ravel_zpf_values(desired_data, [x, y], {'T': conds[v.T]})
 
         # two phase

--- a/espei/plot.py
+++ b/espei/plot.py
@@ -307,8 +307,8 @@ def dataplot(comps, phases, conds, datasets, tielines=True, ax=None, plot_kwargs
                 warnings.warn("'{0}' passed as plotting keyword argument to dataplot, but the alias '{1}' is already set to '{2}'. Use the full version of the keyword argument '{1}' to override the default.".format(aliased_arg, actual_arg, scatter_kwargs.get(actual_arg)))
         scatter_kwargs.update(plot_kwargs)
 
-        # Only fixed T supported for isopotential ternary projections
-        eq_dict = ravel_zpf_values(desired_data, [x, y], {'T': conds[v.T]})
+        # Axes must both be molar quantities, so assume that P and T potentials are not fixed
+        eq_dict = ravel_zpf_values(desired_data, [x, y], {'T': conds[v.T], 'P': conds[v.P]})
 
         # two phase
         updated_tieline_plot_kwargs = {'linewidth':1, 'color':'k'}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -28,6 +28,21 @@ def test_dataplot_runs(datasets_db):
     plt.close(fig)
 
 
+def test_dataplot_runs_ternary_isothermal(datasets_db):
+    """Test that dataplot runs without an error for a ternary isothermal case."""
+
+    datasets_db.insert(dataset_multi_valid_ternary)
+
+    comps = ['AL', 'CR', 'NI', 'VA']
+    phases = ['AL3NI2', 'BCC_B2']
+    conds = {v.P: 101325, v.T: 1348.0, v.X('CR'): (0, 1, 0.01), v.X('NI'): (0, 1, 0.01)}
+    fig = plt.figure()
+    dataplot(comps, phases, conds, datasets_db)
+    # fig.savefig('test_dataplot_runs-figure.png')
+    plt.close(fig)
+
+
+
 def test_plot_interaction_runs(datasets_db):
     """Test that plot_interaction runs without an error."""
     dbf = Database(CU_MG_TDB)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -31,11 +31,11 @@ def test_dataplot_runs(datasets_db):
 def test_dataplot_runs_ternary_isothermal(datasets_db):
     """Test that dataplot runs without an error for a ternary isothermal case."""
 
-    datasets_db.insert(dataset_multi_valid_ternary)
+    datasets_db.insert(A_B_C_DATASET_TERNARY_PHASE_EQUILIBRIA)
 
-    comps = ['AL', 'CR', 'NI', 'VA']
-    phases = ['AL3NI2', 'BCC_B2']
-    conds = {v.P: 101325, v.T: 1348.0, v.X('CR'): (0, 1, 0.01), v.X('NI'): (0, 1, 0.01)}
+    comps = ['A', 'B', 'C', 'VA']
+    phases = ['PHASE_1', 'PHASE_2']
+    conds = {v.P: 101325, v.T: 300.0, v.X('B'): (0, 1, 0.01), v.X('C'): (0, 1, 0.01)}
     fig = plt.figure()
     dataplot(comps, phases, conds, datasets_db)
     # fig.savefig('test_dataplot_runs-figure.png')


### PR DESCRIPTION
Isothermal ternaries were broken by #240 by a bad error check that the `y` variable was temperature. For ternary triangular projections, both `x` and `y` should be molar quantities (i.e. `v.X()`). Both temperature and pressure need to be fixed scalars and therefore the filtering for `ravel_zpf_values` should be filtering against both potentials. 