### PR TITLE
Minor ENH to espei_script.py

### DIFF
--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -274,7 +274,16 @@ def main():
     # if desired, check datasets and return
     if args.check_datasets:
         dataset_filenames = sorted(recursive_glob(args.check_datasets, '*.json'))
+        
+        #if the path is a file, add that file to the list (test single dataset case!)
+        if(os.path.isfile(args.check_datasets)):
+            dataset_filenames.append(os.path.normpath(args.check_datasets))
+            
+        #if there are no input files, warn the user they may have typed the wrong path
         errors = []
+        if(len(dataset_filenames) == 0):
+            errors.append(OSError("No input .json files detected at "+str(os.path.normpath(args.check_datasets))+", is your path correct?"))
+        
         for dataset in dataset_filenames:
             try:
                 load_datasets([dataset])


### PR DESCRIPTION
Added support for single .json file to be checked:
    - Previously, "espei --check-datasets datafolder/jsonfile.json" would return silently, because "datafolder/jsonfile.json" is not a folder
    - Now, "espei --check-datasets datafolder/jsonfile.json" will check jsonfile.json, similarly to if you called  "espei --check-datasets datafolder"

Added check that there is at least 1 .json file in the path specified
    - Previously, "espei --check-datasets datafoldr" would return silently, because there are no json files at the misspelled, nonexistent "datafoldr" folder
    - Now "espei --check-datasets datafoldr" will warn the user that there are no json files at the path, and maybe they have a typo