### PR TITLE
BLD: Support pydantic v2

### DIFF
--- a/espei/phase_models.py
+++ b/espei/phase_models.py
@@ -11,7 +11,7 @@ class ModelMetadata(BaseModel):
     sublattice_model: List[List[ComponentName]]
     sublattice_site_ratios: List[PositiveFloat]
     # Fully qualified import path for a Python class that follows the pycalphad.Model API
-    model: Optional[PyObject]
+    model: Optional[PyObject] = None
 
 
 class PhaseModelSpecification(BaseModel):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'matplotlib',
         'numpy>=1.20',
         'pycalphad>=0.10.1',
-        'pydantic',
+        'pydantic>2.0',
         'pyyaml',
         'setuptools_scm[toml]>=6.0',
         'scikit-learn>=1.0',


### PR DESCRIPTION
Fix use of `Optional[PyObject]` by setting an explicit default which is now required in pydantic v2