### PR TITLE
FIX: Fix Residual protocol for MCMC for Python 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/espei/error_functions/activity_error.py
+++ b/espei/error_functions/activity_error.py
@@ -190,7 +190,7 @@ class ActivityResidual(ResidualFunction):
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):
-        super().__init__(database, datasets, phase_models, symbols_to_fit)
+        super().__init__(database, datasets, phase_models, symbols_to_fit, weight)
 
         if weight is not None:
             self.weight = weight.get("ACR", 1.0)

--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -291,7 +291,7 @@ class EquilibriumPropertyResidual(ResidualFunction):
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):
-        super().__init__(database, datasets, phase_models, symbols_to_fit)
+        super().__init__(database, datasets, phase_models, symbols_to_fit, weight)
 
         if weight is not None:
             self.weight = weight

--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -332,7 +332,7 @@ class FixedConfigurationPropertyResidual(ResidualFunction):
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):
-        super().__init__(database, datasets, phase_models, symbols_to_fit)
+        super().__init__(database, datasets, phase_models, symbols_to_fit, weight)
 
         if weight is not None:
             self.weight = weight

--- a/espei/error_functions/residual_base.py
+++ b/espei/error_functions/residual_base.py
@@ -50,8 +50,8 @@ class ResidualFunction(Protocol):
         database: Database,
         datasets: PickleableTinyDB,
         phase_models: PhaseModelSpecification,
-        symbols_to_fit: Optional[List[SymbolName]],
-        weight: Optional[Dict[str, float]],
+        symbols_to_fit: Optional[List[SymbolName]] = None,
+        weight: Optional[Dict[str, float]] = None,
         ):
         ...
 

--- a/espei/error_functions/zpf_error.py
+++ b/espei/error_functions/zpf_error.py
@@ -439,7 +439,7 @@ class ZPFResidual(ResidualFunction):
         symbols_to_fit: Optional[List[SymbolName]] = None,
         weight: Optional[Dict[str, float]] = None,
         ):
-        super().__init__(database, datasets, phase_models, symbols_to_fit)
+        super().__init__(database, datasets, phase_models, symbols_to_fit, weight)
         if weight is not None:
             self.weight = weight.get("ZPF", 1.0)
         else:


### PR DESCRIPTION
It seems that Python 3.11 changed the behavior of calling `super().__init__` for `Protocol` subclasses that have `Optional` arguments and subclasses of the `Residual` protocol are raising. 

This PR adds Python 3.11 to the CI test matrix and fixes the protocol signature (making the optional arguments actually optional) and also updates the callers that had incorrect signatures.