### PR TITLE
FIX: Dataset exclusion query for duplicated excluded model contributions

### DIFF
--- a/espei/error_functions/non_equilibrium_thermochemical_error.py
+++ b/espei/error_functions/non_equilibrium_thermochemical_error.py
@@ -324,7 +324,7 @@ def get_thermochemical_data(dbf, comps, phases, datasets, model=None, weight_dic
                 if exclusion == tuple([]):
                     exc_search = (~where('excluded_model_contributions').exists()) & (where('solver').exists())
                 else:
-                    exc_search = (where('excluded_model_contributions').test(lambda x: tuple(sorted(x)) == exclusion)) & (where('solver').exists())
+                    exc_search = (where('excluded_model_contributions').test(lambda x: tuple(sorted(set(x))) == exclusion)) & (where('solver').exists())
                 curr_data = get_prop_data(comps, phase_name, prop, datasets, additional_query=exc_search)
                 curr_data = filter_sublattice_configurations(curr_data, constituents)
                 curr_data = filter_temperatures(curr_data)

--- a/tests/test_error_functions.py
+++ b/tests/test_error_functions.py
@@ -100,6 +100,21 @@ def test_fixed_configuration_residual_function(datasets_db):
     assert np.isclose(likelihood, -14.28729, rtol=1e-6)
 
 
+def test_fixed_configuration_residual_function_duplicate_excluded_model_contributions(datasets_db):
+    """Datasets where a excluded model contribution is duplicated is in the excluded model contributions contributes to the residual"""
+    dbf = Database(CU_MG_TDB)
+    datasets_db.insert(CU_MG_HM_MIX_CUMG2_ANTISITE_DUPLICATE_EXCLUDED_MODEL_CONTRIBUTIONS)
+
+    residual_func = FixedConfigurationPropertyResidual(dbf, datasets_db, phase_models=None, symbols_to_fit=[])
+
+    # Regression test "truth" values - got values by running
+    residuals, weights = residual_func.get_residuals(np.asarray([]))
+    assert len(residuals) == len(weights)
+    assert np.allclose(residuals, [-10.0, -100.0])
+    likelihood = residual_func.get_likelihood(np.asarray([]))
+    assert np.isclose(likelihood, -14.28729, rtol=1e-6)
+
+
 def test_fixed_configuration_residual_with_internal_degrees_of_freedom(datasets_db):
     """Unstable endmembers in phases that have internal degrees of freedom should retain fixed internal DOF"""
     dbf = Database(CU_MG_TDB)

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -385,6 +385,28 @@ CU_MG_HM_MIX_CUMG2_ANTISITE = yaml.load("""{
 """, Loader=YAML_LOADER)
 
 
+CU_MG_HM_MIX_CUMG2_ANTISITE_DUPLICATE_EXCLUDED_MODEL_CONTRIBUTIONS = yaml.load("""{
+  "components": ["CU", "MG", "VA"],
+  "phases": ["CUMG2"],
+  "solver": {
+    "sublattice_site_ratios": [1, 2],
+    "sublattice_configurations": [["CU", "MG"], ["MG", "CU"], ["MG", "MG"], ["CU", "CU"]],
+    "mode": "manual"
+  },
+  "conditions": {
+    "P": 101325,
+    "T": [300, 400],
+  },
+
+  "output": "HM_MIX",
+    "values":   [[[10, 11, 12, 13], [100, 101, 102, 103]]],
+  "reference": "FAKE DATA",
+  "comment": "FAKE DATA",
+  "excluded_model_contributions": ["idmix", "idmix"]
+}
+""", Loader=YAML_LOADER)
+
+
 CU_MG_HM_MIX_CUMG2_ALL_INVALID = yaml.load("""{
   "components": ["CU", "MG", "VA"],
   "phases": ["CUMG2"],


### PR DESCRIPTION
If a fixed site fraction dataset has duplicated excluded model contributions, (which can happen if applying the same contribution in two different tags, for example), e.g.

```json
{
    "components": ["CU","MG"],
    "phases": ["CUMG2"],
    "solver": {
        "mode": "manual",
        "sublattice_site_ratios": [1,2],
        "sublattice_configurations": [["CU","MG"]]
    },
    "conditions": { "P": 101325, "T": 298.15},
    "output": "SM_FORM",
    "values": [[[-4.4]]],
    "reference": "Estimated from Zhou (2007)",
    "bibtex": "zhou2007",
    "comment": "Estimated from enthalpy by s=h/3000",
    "excluded_model_contributions": ["idmix", "mag", "idmix", "mag"]
}
```

the current behavior of the code will result in the excluded model contribution query failing and the dataset gets filtered out.

This change resolves that behavior.

- [x] Needs a test to be merged