### PR TITLE
Mobility fitting compatibility and context futures

### DIFF
--- a/espei/error_functions/equilibrium_thermochemical_error.py
+++ b/espei/error_functions/equilibrium_thermochemical_error.py
@@ -160,6 +160,7 @@ def get_equilibrium_thermochemical_data(dbf: Database, comps: Sequence[str],
         # data that isn't ZPF or non-equilibrium thermochemical
         (where('output') != 'ZPF') & (~where('solver').exists()) &
         (where('output').test(lambda x: 'ACR' not in x)) &  # activity data not supported yet
+        (where('output').test(lambda x: 'DIFF' not in x)) & (where('output').test(lambda x: 'TRACER' not in x)) & # ignore diffusivity
         (where('components').test(lambda x: set(x).issubset(comps))) &
         (where('phases').test(lambda x: set(x).issubset(set(phases))))
     )

--- a/espei/espei_script.py
+++ b/espei/espei_script.py
@@ -240,6 +240,8 @@ def run_espei(run_settings):
         data_weights = mcmc_settings.get('data_weights')
         syms = mcmc_settings.get('symbols')
         approximate_equilibrium = mcmc_settings.get('approximate_equilibrium')
+        additional_mcmc_args = {}
+        additional_mcmc_args['use_futures'] = mcmc_settings.get('use_futures', True)
 
         # set up and run the EmceeOptimizer
         optimizer = EmceeOptimizer(dbf, phase_models=phase_models, scheduler=client)
@@ -252,6 +254,7 @@ def run_espei(run_settings):
                       tracefile=tracefile, probfile=probfile,
                       mcmc_data_weights=data_weights,
                       approximate_equilibrium=approximate_equilibrium,
+                      additional_mcmc_args=additional_mcmc_args
                       )
 
         optimizer.dbf.to_file(output_settings['output_db'], if_exists='overwrite')

--- a/espei/input-schema.yaml
+++ b/espei/input-schema.yaml
@@ -133,3 +133,7 @@ mcmc:
       default: {'ZPF': 1.0, 'ACR': 1.0, 'HM': 1.0, 'SM': 1.0, 'CPM': 1.0}
     symbols:
       type: list
+    use_futures:
+      type: boolean
+      default: True
+      required: True

--- a/espei/utils.py
+++ b/espei/utils.py
@@ -52,13 +52,24 @@ class ImmediateClient(Client):
     A subclass of distributed.Client that automatically unwraps the Futures
     returned by map.
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_futures = True
+
     def map(self, f, *iterators, **kwargs):
         """Map a function on a sequence of arguments.
 
         Any keyword arguments are passed to distributed.Client.map
         """
+        #_client = super(ImmediateClient, self)
+        #result = _client.gather(_client.map(f, *[list(it) for it in iterators], **kwargs))
+        #return result
         _client = super(ImmediateClient, self)
-        result = _client.gather(_client.map(f, *[list(it) for it in iterators], **kwargs))
+        if self.use_futures:
+            params = list(*[list(it) for it in iterators])
+            result = _client.gather([f(p) for p in params])
+        else:
+            result = _client.gather(_client.map(f, *[list(it) for it in iterators], **kwargs))
         return result
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -109,6 +109,20 @@ mcmc:
   input_db: dft.tdb
 """
 
+MCMC_RUN_DICT_ADDITIONAL_ARGS = {
+    'mcmc':
+    {
+        'iterations': 1000,
+        'input_db': 'input.tdb',
+        'use_futures': True,
+    },
+    'system':
+    {
+        'datasets': 'ds_path',
+        'phase_models': 'phases.json'
+    }
+}
+
 
 def test_input_yaml_valid_for_full_run():
     """A minimal full run input file should validate"""
@@ -198,3 +212,7 @@ def test_nullable_arguments_are_all_nullable():
     assert null_settings['output']['logfile'] is None
     assert null_settings['output']['probfile'] is None
     assert null_settings['mcmc']['scheduler'] is None
+
+def test_input_yaml_valid_for_mcmc_with_additional_args():
+    d = get_run_settings(MCMC_RUN_DICT_ADDITIONAL_ARGS)
+    assert d.get('generate_parameters') is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -183,6 +183,7 @@ def test_correct_defaults_are_applied_from_minimal_specification():
     assert d['mcmc'].pop('approximate_equilibrium') is False
     assert d['mcmc'].pop('data_weights') == {'ACR': 1.0, 'CPM': 1.0, 'HM': 1.0, 'SM': 1.0, 'ZPF': 1.0}
     assert d['mcmc'].pop('prior') == {'name': 'zero'}
+    assert d['mcmc'].pop('use_futures') is True
     assert len(d['mcmc']) == 1
 
 


### PR DESCRIPTION
This adds the following:
- Compatiblity with https://github.com/materialsgenomefoundation/kawin/pull/19. Only change here is for the thermochemical equilibrium residual to ignore any datasets with `TRACER` or `DIFF` in the `output` field. Then the residual functions implemented in kawin will provide support for tracer and interdiffusivity residual functions
- Option to scatter the context to the Dask workers before emcee is called rather than moving it to the workers during each MCMC iteration. This helps with memory management where pickling/unpickling of the context should only occur once before emcee and anytime a worker is restarted. 
  - This is currently set to be the default behavior
  - Some log statements are also added to track the total memory and memory per worker at each iteration