### PR TITLE
removed `pkg_resources`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/espei/refdata.py
+++ b/espei/refdata.py
@@ -40,9 +40,10 @@ def find_and_insert_user_refstate(entry_point_plugin_name='espei.reference_state
   ``BOCK2015`` and  ``BOCK2015SER``, which define the reference states.
 
   """
-  import pkg_resources
+  from importlib.metadata import entry_points
+
   found_refstates = []
-  for entry_point in pkg_resources.iter_entry_points(entry_point_plugin_name):
+  for entry_point in entry_points(group=entry_point_plugin_name):
     user_module = entry_point.load()
     refstate_name = entry_point.name
     namespace[refstate_name] = getattr(user_module, refstate_name)


### PR DESCRIPTION
Importing of `pkg_resources` is deprecated.

https://setuptools.pypa.io/en/latest/pkg_resources.html

The new way to handle plugins is illustrated below:

```python
def discover_pytest_plugins_old():
    """Find installed pytest plugins using pkg_resources"""
    import pkg_resources
    
    plugins = {}
    # Look for pytest plugins (pytest11 is pytest's entry point group)
    for entry_point in pkg_resources.iter_entry_points('pytest11'):
        try:
            plugin = entry_point.load()
            plugins[entry_point.name] = plugin
            print(f"Found plugin: {entry_point.name}")
        except Exception as e:
            print(f"Failed to load plugin {entry_point.name}: {e}")
    return plugins

def discover_pytest_plugins_new():
    """Find installed pytest plugins using importlib.metadata"""
    from importlib.metadata import entry_points
    
    plugins = {}
    eps = entry_points(group='pytest11')
    for entry_point in eps:
        try:
            plugin = entry_point.load()
            plugins[entry_point.name] = plugin
            print(f"Found plugin: {entry_point.name}")
        except Exception as e:
            print(f"Failed to load plugin {entry_point.name}: {e}")
    return plugins
    
print(discover_pytest_plugins_old())
print(discover_pytest_plugins_new())
```
